### PR TITLE
Tidy up to pass rule runner to linters not config map

### DIFF
--- a/src/main/java/com/wcg/liquibase/Linter.java
+++ b/src/main/java/com/wcg/liquibase/Linter.java
@@ -1,13 +1,11 @@
 package com.wcg.liquibase;
 
-import com.wcg.liquibase.config.RuleConfig;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import liquibase.change.Change;
 import liquibase.exception.ChangeLogParseException;
 
-import java.util.Map;
-
 public interface Linter<T extends Change> {
 
-    void lint(T change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException;
+    void lint(T change, RuleRunner ruleRunner) throws ChangeLogParseException;
 
 }

--- a/src/main/java/com/wcg/liquibase/config/Config.java
+++ b/src/main/java/com/wcg/liquibase/config/Config.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wcg.liquibase.config.rules.RuleRunner;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +39,10 @@ public class Config {
 
     public Map<String, RuleConfig> getRules() {
         return rules;
+    }
+
+    public RuleRunner getRuleRunner() {
+        return new RuleRunner(this.rules);
     }
 
     Config mixin(Config toMix) {

--- a/src/main/java/com/wcg/liquibase/config/rules/RuleRunner.java
+++ b/src/main/java/com/wcg/liquibase/config/rules/RuleRunner.java
@@ -7,48 +7,57 @@ import liquibase.changelog.DatabaseChangeLog;
 import liquibase.exception.ChangeLogParseException;
 
 import java.util.Map;
-import java.util.function.Supplier;
 
 public class RuleRunner {
 
     private final Map<String, RuleConfig> ruleConfigs;
-    private final Change change;
-    private final DatabaseChangeLog databaseChangeLog;
 
-    private RuleRunner(Map<String, RuleConfig> ruleConfigs, Change change, DatabaseChangeLog databaseChangeLog) {
+    public RuleRunner(Map<String, RuleConfig> ruleConfigs) {
         this.ruleConfigs = ruleConfigs;
-        this.change = change;
-        this.databaseChangeLog = databaseChangeLog;
     }
 
-    public static RuleRunner forChange(final Map<String, RuleConfig> ruleConfigs, final Change change) {
-        return new RuleRunner(ruleConfigs, change, null);
+    public RunningContext forChange(Change change) {
+        return new RunningContext(this.ruleConfigs, change, null);
     }
 
-    public static RuleRunner forDatabaseChangeLog(final Map<String, RuleConfig> ruleConfigs, final DatabaseChangeLog databaseChangeLog) {
-        return new RuleRunner(ruleConfigs, null, databaseChangeLog);
+    public RunningContext forDatabaseChangeLog(DatabaseChangeLog databaseChangeLog) {
+        return new RunningContext(ruleConfigs, null, databaseChangeLog);
     }
 
-    public static RuleRunner forGeneric(final Map<String, RuleConfig> ruleConfigs) {
-        return new RuleRunner(ruleConfigs, null, null);
+    public RunningContext forGeneric() {
+        return new RunningContext(ruleConfigs, null, null);
     }
 
-    public RuleRunner run(RuleType ruleType, Object object) throws ChangeLogParseException {
-        final Rule rule = ruleType.create(ruleConfigs);
-        if (shouldApply(rule, change) && rule.invalid(object, change)) {
-            throw ChangeLogParseExceptionHelper.build(databaseChangeLog, change, rule.buildErrorMessage(object, change));
+    public static class RunningContext {
+
+        private final Map<String, RuleConfig> ruleConfigs;
+        private final Change change;
+        private final DatabaseChangeLog databaseChangeLog;
+
+        private RunningContext(Map<String, RuleConfig> ruleConfigs, Change change, DatabaseChangeLog databaseChangeLog) {
+            this.ruleConfigs = ruleConfigs;
+            this.change = change;
+            this.databaseChangeLog = databaseChangeLog;
         }
-        return this;
-    }
 
-    private boolean shouldApply(Rule rule, Change change) {
-        return rule.getRuleConfig().isEnabled() && evaluateCondition(rule, change);
-    }
+        public RunningContext run(RuleType ruleType, Object object) throws ChangeLogParseException {
+            final Rule rule = ruleType.create(ruleConfigs);
+            if (shouldApply(rule, change) && rule.invalid(object, change)) {
+                throw ChangeLogParseExceptionHelper.build(databaseChangeLog, change, rule.buildErrorMessage(object, change));
+            }
+            return this;
+        }
 
-    private boolean evaluateCondition(Rule rule, Change change) {
-        return rule.getRuleConfig().getConditionalExpression()
-                .map(expression -> expression.getValue(change, boolean.class))
-                .orElse(true);
+        private boolean shouldApply(Rule rule, Change change) {
+            return rule.getRuleConfig().isEnabled() && evaluateCondition(rule, change);
+        }
+
+        private boolean evaluateCondition(Rule rule, Change change) {
+            return rule.getRuleConfig().getConditionalExpression()
+                    .map(expression -> expression.getValue(change, boolean.class))
+                    .orElse(true);
+        }
+
     }
 
 }

--- a/src/main/java/com/wcg/liquibase/linters/AddColumnChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/AddColumnChangeLinter.java
@@ -1,12 +1,10 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import liquibase.change.AddColumnConfig;
 import liquibase.change.core.AddColumnChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class AddColumnChangeLinter implements Linter<AddColumnChange> {
 
@@ -14,11 +12,11 @@ public class AddColumnChangeLinter implements Linter<AddColumnChange> {
     private ObjectNameLinter objectNameLinter = new ObjectNameLinter();
 
     @Override
-    public void lint(AddColumnChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
+    public void lint(AddColumnChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
         for (AddColumnConfig addColumnConfig : change.getColumns()) {
-            getObjectNameLinter().lintObjectName(addColumnConfig.getName(), change, ruleConfigs);
+            getObjectNameLinter().lintObjectName(addColumnConfig.getName(), change, ruleRunner);
         }
-        getColumnConfigLinter().lintColumnConfig(change, ruleConfigs);
+        getColumnConfigLinter().lintColumnConfig(change, ruleRunner);
     }
 
     ColumnConfigLinter getColumnConfigLinter() {

--- a/src/main/java/com/wcg/liquibase/linters/AddForeignKeyConstraintChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/AddForeignKeyConstraintChangeLinter.java
@@ -1,22 +1,19 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
 import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import liquibase.change.core.AddForeignKeyConstraintChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class AddForeignKeyConstraintChangeLinter implements Linter<AddForeignKeyConstraintChange> {
 
     private static final ObjectNameLinter objectNameLinter = new ObjectNameLinter();
 
     @Override
-    public void lint(AddForeignKeyConstraintChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        getObjectNameLinter().lintObjectNameLength(change.getConstraintName(), change, ruleConfigs);
-        RuleRunner.forChange(ruleConfigs, change)
+    public void lint(AddForeignKeyConstraintChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        getObjectNameLinter().lintObjectNameLength(change.getConstraintName(), change, ruleRunner);
+        ruleRunner.forChange(change)
                 .run(RuleType.FOREIGN_KEY_MUST_BE_NAMED, change.getConstraintName())
                 .run(RuleType.FOREIGN_KEY_MUST_USE_BASE_AND_REFERENCE_TABLE_NAME, change.getConstraintName());
     }

--- a/src/main/java/com/wcg/liquibase/linters/AddPrimaryKeyChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/AddPrimaryKeyChangeLinter.java
@@ -1,22 +1,19 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
 import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import liquibase.change.core.AddPrimaryKeyChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class AddPrimaryKeyChangeLinter implements Linter<AddPrimaryKeyChange> {
 
     private static final ObjectNameLinter objectNameLinter = new ObjectNameLinter();
 
     @Override
-    public void lint(AddPrimaryKeyChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        getObjectNameLinter().lintObjectNameLength(change.getConstraintName(), change, ruleConfigs);
-        RuleRunner.forChange(ruleConfigs, change)
+    public void lint(AddPrimaryKeyChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        getObjectNameLinter().lintObjectNameLength(change.getConstraintName(), change, ruleRunner);
+        ruleRunner.forChange(change)
                 .run(RuleType.PRIMARY_KEY_MUST_BE_NAMED, change.getConstraintName())
                 .run(RuleType.PRIMARY_KEY_MUST_USE_TABLE_NAME, change.getConstraintName());
     }

--- a/src/main/java/com/wcg/liquibase/linters/AddUniqueConstraintChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/AddUniqueConstraintChangeLinter.java
@@ -1,22 +1,19 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
 import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import liquibase.change.core.AddUniqueConstraintChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class AddUniqueConstraintChangeLinter implements Linter<AddUniqueConstraintChange> {
 
     private static final ObjectNameLinter objectNameLinter = new ObjectNameLinter();
 
     @Override
-    public void lint(AddUniqueConstraintChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        getObjectNameLinter().lintObjectNameLength(change.getConstraintName(), change, ruleConfigs);
-        RuleRunner.forChange(ruleConfigs, change).run(RuleType.UNIQUE_CONSTRAINT_NAME, change.getConstraintName());
+    public void lint(AddUniqueConstraintChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        getObjectNameLinter().lintObjectNameLength(change.getConstraintName(), change, ruleRunner);
+        ruleRunner.forChange(change).run(RuleType.UNIQUE_CONSTRAINT_NAME, change.getConstraintName());
     }
 
     ObjectNameLinter getObjectNameLinter() {

--- a/src/main/java/com/wcg/liquibase/linters/ColumnConfigLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/ColumnConfigLinter.java
@@ -1,6 +1,5 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.RuleConfig;
 import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import liquibase.change.Change;
@@ -9,14 +8,12 @@ import liquibase.change.ColumnConfig;
 import liquibase.change.ConstraintsConfig;
 import liquibase.exception.ChangeLogParseException;
 
-import java.util.Map;
-
 class ColumnConfigLinter {
 
-    void lintColumnConfig(ChangeWithColumns<? extends ColumnConfig> change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
+    void lintColumnConfig(ChangeWithColumns<? extends ColumnConfig> change, RuleRunner ruleRunner) throws ChangeLogParseException {
         for (ColumnConfig columnConfig : change.getColumns()) {
             final ConstraintsConfig constraints = columnConfig.getConstraints();
-            RuleRunner.forChange(ruleConfigs, (Change) change)
+            ruleRunner.forChange((Change) change)
                     .run(RuleType.CREATE_COLUMN_REMARKS, columnConfig.getRemarks())
                     .run(RuleType.CREATE_COLUMN_NULLABLE_CONSTRAINT, constraints)
                     .run(RuleType.CREATE_COLUMN_NO_DEFINE_PRIMARY_KEY, constraints);

--- a/src/main/java/com/wcg/liquibase/linters/CreateIndexChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/CreateIndexChangeLinter.java
@@ -1,22 +1,19 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
 import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import liquibase.change.core.CreateIndexChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class CreateIndexChangeLinter implements Linter<CreateIndexChange> {
 
     private static final ObjectNameLinter objectNameLinter = new ObjectNameLinter();
 
     @Override
-    public void lint(CreateIndexChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        getObjectNameLinter().lintObjectNameLength(change.getIndexName(), change, ruleConfigs);
-        RuleRunner.forChange(ruleConfigs, change).run(RuleType.CREATE_INDEX_NAME, change.getIndexName());
+    public void lint(CreateIndexChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        getObjectNameLinter().lintObjectNameLength(change.getIndexName(), change, ruleRunner);
+        ruleRunner.forChange(change).run(RuleType.CREATE_INDEX_NAME, change.getIndexName());
     }
 
     ObjectNameLinter getObjectNameLinter() {

--- a/src/main/java/com/wcg/liquibase/linters/CreateTableChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/CreateTableChangeLinter.java
@@ -1,13 +1,10 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
 import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import liquibase.change.core.CreateTableChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class CreateTableChangeLinter implements Linter<CreateTableChange> {
 
@@ -15,10 +12,10 @@ public class CreateTableChangeLinter implements Linter<CreateTableChange> {
     private TableNameLinter tableNameLinter = new TableNameLinter();
 
     @Override
-    public void lint(CreateTableChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        RuleRunner.forChange(ruleConfigs, change).run(RuleType.CREATE_TABLE_REMARKS, change.getRemarks());
-        getTableNameLinter().lintTableName(change.getTableName(), change, ruleConfigs);
-        getColumnConfigLinter().lintColumnConfig(change, ruleConfigs);
+    public void lint(CreateTableChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        ruleRunner.forChange(change).run(RuleType.CREATE_TABLE_REMARKS, change.getRemarks());
+        getTableNameLinter().lintTableName(change.getTableName(), change, ruleRunner);
+        getColumnConfigLinter().lintColumnConfig(change, ruleRunner);
     }
 
     ColumnConfigLinter getColumnConfigLinter() {

--- a/src/main/java/com/wcg/liquibase/linters/MergeColumnChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/MergeColumnChangeLinter.java
@@ -1,19 +1,17 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import liquibase.change.core.MergeColumnChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class MergeColumnChangeLinter implements Linter<MergeColumnChange> {
 
     private ObjectNameLinter objectNameLinter = new ObjectNameLinter();
 
     @Override
-    public void lint(MergeColumnChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        getObjectNameLinter().lintObjectName(change.getFinalColumnName(), change, ruleConfigs);
+    public void lint(MergeColumnChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        getObjectNameLinter().lintObjectName(change.getFinalColumnName(), change, ruleRunner);
     }
 
     ObjectNameLinter getObjectNameLinter() {

--- a/src/main/java/com/wcg/liquibase/linters/ModifyDataChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/ModifyDataChangeLinter.java
@@ -1,19 +1,16 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
 import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import liquibase.change.core.AbstractModifyDataChange;
 import liquibase.exception.ChangeLogParseException;
 
-import java.util.Map;
-
 public class ModifyDataChangeLinter implements Linter<AbstractModifyDataChange> {
 
     @Override
-    public void lint(AbstractModifyDataChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        RuleRunner.forChange(ruleConfigs, change)
+    public void lint(AbstractModifyDataChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        ruleRunner.forChange(change)
                 .run(RuleType.MODIFY_DATA_ENFORCE_WHERE, change)
                 .run(RuleType.MODIFY_DATA_STARTS_WITH_WHERE, change);
     }

--- a/src/main/java/com/wcg/liquibase/linters/ObjectNameLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/ObjectNameLinter.java
@@ -1,25 +1,22 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.ChangeLogParseExceptionHelper;
-import com.wcg.liquibase.config.RuleConfig;
 import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import liquibase.change.AbstractChange;
 import liquibase.exception.ChangeLogParseException;
 
-import java.util.Map;
-
 public class ObjectNameLinter {
 
-    void lintObjectName(final String objectName, final AbstractChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
+    void lintObjectName(final String objectName, final AbstractChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
         ensureNameTruthy(objectName, change);
-        RuleRunner.forChange(ruleConfigs, change).run(RuleType.OBJECT_NAME, objectName);
-        lintObjectNameLength(objectName, change, ruleConfigs);
+        ruleRunner.forChange(change).run(RuleType.OBJECT_NAME, objectName);
+        lintObjectNameLength(objectName, change, ruleRunner);
     }
 
-    void lintObjectNameLength(final String objectName, final AbstractChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
+    void lintObjectNameLength(final String objectName, final AbstractChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
         ensureNameTruthy(objectName, change);
-        RuleRunner.forChange(ruleConfigs, change).run(RuleType.OBJECT_NAME_LENGTH, objectName);
+        ruleRunner.forChange(change).run(RuleType.OBJECT_NAME_LENGTH, objectName);
     }
 
     private void ensureNameTruthy(String objectName, AbstractChange change) throws ChangeLogParseException {

--- a/src/main/java/com/wcg/liquibase/linters/RenameColumnChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/RenameColumnChangeLinter.java
@@ -1,19 +1,17 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import liquibase.change.core.RenameColumnChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class RenameColumnChangeLinter implements Linter<RenameColumnChange> {
 
     private ObjectNameLinter objectNameLinter = new ObjectNameLinter();
 
     @Override
-    public void lint(RenameColumnChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        getObjectNameLinter().lintObjectName(change.getNewColumnName(), change, ruleConfigs);
+    public void lint(RenameColumnChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        getObjectNameLinter().lintObjectName(change.getNewColumnName(), change, ruleRunner);
     }
 
     ObjectNameLinter getObjectNameLinter() {

--- a/src/main/java/com/wcg/liquibase/linters/RenameTableChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/RenameTableChangeLinter.java
@@ -1,19 +1,17 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import liquibase.change.core.RenameTableChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class RenameTableChangeLinter implements Linter<RenameTableChange> {
 
     private TableNameLinter tableNameLinter = new TableNameLinter();
 
     @Override
-    public void lint(RenameTableChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        getTableNameLinter().lintTableName(change.getNewTableName(), change, ruleConfigs);
+    public void lint(RenameTableChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        getTableNameLinter().lintTableName(change.getNewTableName(), change, ruleRunner);
     }
 
     TableNameLinter getTableNameLinter() {

--- a/src/main/java/com/wcg/liquibase/linters/RenameViewChangeLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/RenameViewChangeLinter.java
@@ -1,19 +1,17 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.Linter;
-import com.wcg.liquibase.config.RuleConfig;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import liquibase.change.core.RenameViewChange;
 import liquibase.exception.ChangeLogParseException;
-
-import java.util.Map;
 
 public class RenameViewChangeLinter implements Linter<RenameViewChange> {
 
     private static final ObjectNameLinter objectNameLinter = new ObjectNameLinter();
 
     @Override
-    public void lint(RenameViewChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        getObjectNameLinter().lintObjectNameLength(change.getNewViewName(), change, ruleConfigs);
+    public void lint(RenameViewChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        getObjectNameLinter().lintObjectNameLength(change.getNewViewName(), change, ruleRunner);
     }
 
     ObjectNameLinter getObjectNameLinter() {

--- a/src/main/java/com/wcg/liquibase/linters/TableNameLinter.java
+++ b/src/main/java/com/wcg/liquibase/linters/TableNameLinter.java
@@ -1,17 +1,14 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.RuleConfig;
 import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import liquibase.change.AbstractChange;
 import liquibase.exception.ChangeLogParseException;
 
-import java.util.Map;
-
 public class TableNameLinter {
 
-    public void lintTableName(final String tableName, final AbstractChange change, Map<String, RuleConfig> ruleConfigs) throws ChangeLogParseException {
-        RuleRunner.forChange(ruleConfigs, change)
+    public void lintTableName(final String tableName, final AbstractChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
+        ruleRunner.forChange(change)
                 .run(RuleType.TABLE_NAME, tableName)
                 .run(RuleType.TABLE_NAME_LENGTH, tableName);
     }

--- a/src/main/java/liquibase/parser/ext/CustomChangeLogParser.java
+++ b/src/main/java/liquibase/parser/ext/CustomChangeLogParser.java
@@ -26,8 +26,9 @@ public class CustomChangeLogParser extends XMLChangeLogSAXParser implements Chan
         }
 
         Config config = configLoader.load(resourceAccessor);
+        RuleRunner ruleRunner = config.getRuleRunner();
 
-        checkSchemaName(parsedNode, config);
+        checkSchemaName(parsedNode, ruleRunner);
 
         DatabaseChangeLog changeLog = new DatabaseChangeLog(physicalChangeLogLocation);
         changeLog.setChangeLogParameters(changeLogParameters);
@@ -37,7 +38,7 @@ public class CustomChangeLogParser extends XMLChangeLogSAXParser implements Chan
             throw new ChangeLogParseException(e);
         }
 
-        changeLogLinter.lintChangeLog(changeLog, config);
+        changeLogLinter.lintChangeLog(changeLog, config, ruleRunner);
         return changeLog;
     }
 
@@ -51,13 +52,13 @@ public class CustomChangeLogParser extends XMLChangeLogSAXParser implements Chan
         return 100;
     }
 
-    void checkSchemaName(ParsedNode parsedNode, Config config) throws ChangeLogParseException {
+    void checkSchemaName(ParsedNode parsedNode, RuleRunner ruleRunner) throws ChangeLogParseException {
         if ("schemaName".equals(parsedNode.getName())) {
-            RuleRunner.forGeneric(config.getRules()).run(RuleType.SCHEMA_NAME, parsedNode.getValue().toString());
+            ruleRunner.forGeneric().run(RuleType.SCHEMA_NAME, parsedNode.getValue().toString());
         }
         if (parsedNode.getChildren() != null && !parsedNode.getChildren().isEmpty()) {
             for (ParsedNode childNode : parsedNode.getChildren()) {
-                checkSchemaName(childNode, config);
+                checkSchemaName(childNode, ruleRunner);
             }
         }
     }

--- a/src/main/java/liquibase/parser/ext/CustomChangeLogParser.java
+++ b/src/main/java/liquibase/parser/ext/CustomChangeLogParser.java
@@ -17,15 +17,17 @@ public class CustomChangeLogParser extends XMLChangeLogSAXParser implements Chan
 
     private ChangeLogLinter changeLogLinter = new ChangeLogLinter();
     private ConfigLoader configLoader = new ConfigLoader();
+    private Config config;
 
     @Override
     public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
+        loadConfig(resourceAccessor);
+
         ParsedNode parsedNode = parseToNode(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
         if (parsedNode == null) {
             return null;
         }
 
-        Config config = configLoader.load(resourceAccessor);
         RuleRunner ruleRunner = config.getRuleRunner();
 
         checkSchemaName(parsedNode, ruleRunner);
@@ -60,6 +62,12 @@ public class CustomChangeLogParser extends XMLChangeLogSAXParser implements Chan
             for (ParsedNode childNode : parsedNode.getChildren()) {
                 checkSchemaName(childNode, ruleRunner);
             }
+        }
+    }
+
+    private void loadConfig(ResourceAccessor resourceAccessor) {
+        if (config == null) {
+            config = configLoader.load(resourceAccessor);
         }
     }
 

--- a/src/test/java/com/wcg/liquibase/ChangeLogLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/ChangeLogLinterTest.java
@@ -2,8 +2,10 @@ package com.wcg.liquibase;
 
 import com.google.common.collect.ImmutableSet;
 import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
 import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.ContextExpression;
 import liquibase.change.Change;
 import liquibase.change.core.AddColumnChange;
@@ -26,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class, RuleRunnerParameterResolver.class})
 class ChangeLogLinterTest {
 
     private ChangeLogLinter changeLogLinter;
@@ -38,93 +40,93 @@ class ChangeLogLinterTest {
 
     @DisplayName("Change set should have at least one context")
     @Test
-    void should_have_at_least_one_context_per_change_set(ChangeSet changeSet, Config config) {
+    void should_have_at_least_one_context_per_change_set(ChangeSet changeSet, Config config, RuleRunner ruleRunner) {
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(changeSet.getChangeLog(), config));
+                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(changeSet.getChangeLog(), config, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Should have at least one context on the change set"));
     }
 
     @DisplayName("Should lint change sets with standard comment")
     @Test
-    void should_lint_change_sets_with_standard_comment(Config config) throws ChangeLogParseException {
+    void should_lint_change_sets_with_standard_comment(Config config, RuleRunner ruleRunner) throws ChangeLogParseException {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("ddl_test"), "Test Data column");
-        changeLogLinter.lintChangeLog(databaseChangeLog, config);
+        changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner);
         verify(changeSet, times(1)).getChanges();
     }
 
 
     @DisplayName("Should not lint change sets with lint disabled comment")
     @Test
-    void should_not_lint_change_sets_with_lint_disabled_comment(Config config) throws ChangeLogParseException {
+    void should_not_lint_change_sets_with_lint_disabled_comment(Config config, RuleRunner ruleRunner) throws ChangeLogParseException {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, null, "coment includes lql-ignore foo");
-        changeLogLinter.lintChangeLog(databaseChangeLog, config);
+        changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner);
         verify(changeSet, never()).getChanges();
     }
 
     @DisplayName("Should not fall over on null comment")
     @Test
-    void should_not_fall_over_on_null_comment(Config config) throws ChangeLogParseException {
+    void should_not_fall_over_on_null_comment(Config config, RuleRunner ruleRunner) throws ChangeLogParseException {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("ddl_test"), "Comment");
-        changeLogLinter.lintChangeLog(databaseChangeLog, config);
+        changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner);
         verify(changeSet, times(1)).getChanges();
     }
 
     @DisplayName("Should not allow more than one ddl_test change in a change set")
     @Test
-    void should_not_allow_more_than_one_ddl_test_change_in_a_change_set(Config config) {
+    void should_not_allow_more_than_one_ddl_test_change_in_a_change_set(Config config, RuleRunner ruleRunner) {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("ddl_test"), "Comment");
         addChangeToChangeSet(changeSet, new AddColumnChange(), new AddColumnChange());
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config));
+                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Should only have a single ddl change per change set"));
     }
 
     @DisplayName("Should allow one ddl_test change in a change set")
     @Test
-    void should_allow_one_ddl_test_change_in_a_change_set(Config config) throws ChangeLogParseException {
+    void should_allow_one_ddl_test_change_in_a_change_set(Config config, RuleRunner ruleRunner) throws ChangeLogParseException {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("ddl_test"), "Comment");
         addChangeToChangeSet(changeSet, new AddColumnChange());
 
-        changeLogLinter.lintChangeLog(databaseChangeLog, config);
+        changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner);
     }
 
     @DisplayName("Should not allow ddl_test changes in context other than ddl_test")
     @Test
-    void should_not_allow_ddl_test_changes_in_context_other_than_ddl_test(Config config) {
+    void should_not_allow_ddl_test_changes_in_context_other_than_ddl_test(Config config, RuleRunner ruleRunner) {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("dml_test"), "Comment");
         addChangeToChangeSet(changeSet, new AddColumnChange());
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config));
+                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Should have a ddl changes under ddl contexts"));
     }
 
     @DisplayName("Should not allow dml changes in ddl_test context")
     @Test
-    void should_not_allow_dml_changes_in_ddl_test_context(Config config) {
+    void should_not_allow_dml_changes_in_ddl_test_context(Config config, RuleRunner ruleRunner) {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("ddl_test"), "Comment");
         addChangeToChangeSet(changeSet, new InsertDataChange());
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config));
+                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Should have a ddl changes under ddl contexts"));
     }
 
     @DisplayName("Should not allow spaces in filename - it causes issues on some platforms")
     @Test
-    void should_not_allow_spaces_in_filename(Config config) {
+    void should_not_allow_spaces_in_filename(Config config, RuleRunner ruleRunner) {
         DatabaseChangeLog passingChangelog = mock(DatabaseChangeLog.class);
         when(passingChangelog.getFilePath()).thenReturn("modules/foo/nice.xml");
 
@@ -132,7 +134,7 @@ class ChangeLogLinterTest {
         when(failingChangelog.getFilePath()).thenReturn("modules/foo/whoops space.xml");
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(failingChangelog, config));
+                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(failingChangelog, config, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Changelog filenames should not contain spaces"));
 
@@ -140,40 +142,40 @@ class ChangeLogLinterTest {
 
     @DisplayName("Should not lint baseline script")
     @Test
-    void should_not_lint_baseline_script(Config config) throws ChangeLogParseException {
+    void should_not_lint_baseline_script(Config config, RuleRunner ruleRunner) throws ChangeLogParseException {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("baseline_ddl_test"), "Test Data column");
-        changeLogLinter.lintChangeLog(databaseChangeLog, config);
+        changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner);
         verify(changeSet, never()).getChanges();
     }
 
     @DisplayName("Should not allow change set without a comment")
     @Test
-    void should_not_allow_change_log_without_comment(Config config) {
+    void should_not_allow_change_log_without_comment(Config config, RuleRunner ruleRunner) {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("dml"), null);
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config));
+                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Change set must have a comment"));
     }
 
     @DisplayName("Should not context with suffix not ending in _test  or _script")
     @Test
-    void should_not_allow_context_with_suffix_not_ending_in_allowed(Config config) {
+    void should_not_allow_context_with_suffix_not_ending_in_allowed(Config config, RuleRunner ruleRunner) {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("dml"), "Comment");
         addChangeToChangeSet(changeSet, new AddColumnChange());
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config));
+                assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Context is incorrect, should end with '_test' or '_script'"));
     }
 
     @Test
-    void should_prevent_precondition(Config config) {
+    void should_prevent_precondition(Config config, RuleRunner ruleRunner) {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("core_test"), "Comment");
         SqlPrecondition precondition = new SqlPrecondition();
@@ -185,7 +187,7 @@ class ChangeLogLinterTest {
         when(changeSet.getPreconditions()).thenReturn(preconditionContainer);
         addChangeToChangeSet(changeSet, new InsertDataChange());
 
-        ChangeLogParseException changeLogParseException = assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config));
+        ChangeLogParseException changeLogParseException = assertThrows(ChangeLogParseException.class, () -> changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Preconditions are not allowed in this project"));
     }

--- a/src/test/java/com/wcg/liquibase/linters/AddColumnChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/AddColumnChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.AddColumnChangeParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.AddColumnConfig;
 import liquibase.change.core.AddColumnChange;
 import liquibase.exception.ChangeLogParseException;
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.mockito.Mockito.*;
 
-@ExtendWith({AddColumnChangeParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({AddColumnChangeParameterResolver.class, RuleRunnerParameterResolver.class})
 class AddColumnChangeLinterTest {
 
     private AddColumnChangeLinter addColumnChangeLinter;
@@ -39,20 +39,20 @@ class AddColumnChangeLinterTest {
 
     @DisplayName("Should call column config linter")
     @Test
-    void should_call_column_config_linter(AddColumnChange addColumnChange, Config config) throws ChangeLogParseException {
+    void should_call_column_config_linter(AddColumnChange addColumnChange, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddColumnConfig addColumnConfig = new AddColumnConfig();
         addColumnConfig.setName("TEST");
         addColumnChange.addColumn(addColumnConfig);
-        addColumnChangeLinter.lint(addColumnChange, config.getRules());
-        verify(columnConfigLinter, times(1)).lintColumnConfig(addColumnChange, config.getRules());
+        addColumnChangeLinter.lint(addColumnChange, ruleRunner);
+        verify(columnConfigLinter, times(1)).lintColumnConfig(addColumnChange, ruleRunner);
     }
 
     @Test
-    void should_use_object_name_linter_for_name_length_check(AddColumnChange addColumnChange, Config config) throws ChangeLogParseException {
+    void should_use_object_name_linter_for_name_length_check(AddColumnChange addColumnChange, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddColumnConfig addColumnConfig = new AddColumnConfig();
         addColumnConfig.setName("TEST");
         addColumnChange.addColumn(addColumnConfig);
-        addColumnChangeLinter.lint(addColumnChange, config.getRules());
-        verify(objectNameLinter, times(1)).lintObjectName("TEST", addColumnChange, config.getRules());
+        addColumnChangeLinter.lint(addColumnChange, ruleRunner);
+        verify(objectNameLinter, times(1)).lintObjectName("TEST", addColumnChange, ruleRunner);
     }
 }

--- a/src/test/java/com/wcg/liquibase/linters/AddForeignKeyConstraintChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/AddForeignKeyConstraintChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.AddForeignKeyConstraintChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class AddForeignKeyConstraintChangeLinterTest {
 
     private AddForeignKeyConstraintChangeLinter addForeignKeyConstraintChangeLinter;
@@ -32,61 +32,61 @@ class AddForeignKeyConstraintChangeLinterTest {
     }
 
     @Test
-    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddForeignKeyConstraintChange addForeignKeyConstraintChange = new AddForeignKeyConstraintChange();
         addForeignKeyConstraintChange.setChangeSet(changeSet);
         addForeignKeyConstraintChange.setBaseTableName("BASE");
         addForeignKeyConstraintChange.setReferencedTableName("REFERENCE");
         addForeignKeyConstraintChange.setConstraintName("BASE_REFERENCE_FK");
-        addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, config.getRules());
-        verify(objectNameLinter, times(1)).lintObjectNameLength("BASE_REFERENCE_FK", addForeignKeyConstraintChange, config.getRules());
+        addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, ruleRunner);
+        verify(objectNameLinter, times(1)).lintObjectNameLength("BASE_REFERENCE_FK", addForeignKeyConstraintChange, ruleRunner);
     }
 
     @DisplayName("Should validate name in incorrect format")
     @Test
-    void should_validate_name_in_incorrect_format(ChangeSet changeSet, Config config) {
+    void should_validate_name_in_incorrect_format(ChangeSet changeSet, RuleRunner ruleRunner) {
         AddForeignKeyConstraintChange addForeignKeyConstraintChange = new AddForeignKeyConstraintChange();
         addForeignKeyConstraintChange.setChangeSet(changeSet);
         addForeignKeyConstraintChange.setBaseTableName("BASE");
         addForeignKeyConstraintChange.setReferencedTableName("REFERENCE");
         addForeignKeyConstraintChange.setConstraintName("TEST_PK_ABC");
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, ruleRunner));
         assertTrue(changeLogParseException.getMessage().contains("Foreign key constraint 'TEST_PK_ABC' must end with '_FK'. e.g. ORDER_CUSTOMER_FK"));
     }
 
     @DisplayName("Should validate name in correct format")
     @Test
-    void should_validate_name_in_correct_format(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_validate_name_in_correct_format(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddForeignKeyConstraintChange addForeignKeyConstraintChange = new AddForeignKeyConstraintChange();
         addForeignKeyConstraintChange.setChangeSet(changeSet);
         addForeignKeyConstraintChange.setBaseTableName("BASE");
         addForeignKeyConstraintChange.setReferencedTableName("REFERENCE");
         addForeignKeyConstraintChange.setConstraintName("BASE_REFERENCE_FK");
-        addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, config.getRules());
+        addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, ruleRunner);
     }
 
     @DisplayName("Should not validate if name in format is longer than max length")
     @Test
-    void should_not_validate_if_name_in_format_more_than_max_length(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_not_validate_if_name_in_format_more_than_max_length(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddForeignKeyConstraintChange addForeignKeyConstraintChange = new AddForeignKeyConstraintChange();
         addForeignKeyConstraintChange.setChangeSet(changeSet);
         addForeignKeyConstraintChange.setBaseTableName("TEST_TEST_TEST_TEST_TEST");
         addForeignKeyConstraintChange.setReferencedTableName("REFERENCE");
         addForeignKeyConstraintChange.setConstraintName("TEST_PK_ABC_FK");
-        addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, config.getRules());
+        addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, ruleRunner);
     }
 
     @DisplayName("Should not validate if name in format but validate ending when longer than max length")
     @Test
-    void should_not_validate_name_in_format_but_validate_ending_when_more_than_max_length(ChangeSet changeSet, Config config) {
+    void should_not_validate_name_in_format_but_validate_ending_when_more_than_max_length(ChangeSet changeSet, RuleRunner ruleRunner) {
         AddForeignKeyConstraintChange addForeignKeyConstraintChange = new AddForeignKeyConstraintChange();
         addForeignKeyConstraintChange.setChangeSet(changeSet);
         addForeignKeyConstraintChange.setBaseTableName("TEST_TEST_TEST_TEST_TEST");
         addForeignKeyConstraintChange.setReferencedTableName("REFERENCE");
         addForeignKeyConstraintChange.setConstraintName("TEST_PK_ABC");
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> addForeignKeyConstraintChangeLinter.lint(addForeignKeyConstraintChange, ruleRunner));
         assertTrue(changeLogParseException.getMessage().contains("Foreign key constraint '" + addForeignKeyConstraintChange.getConstraintName() + "' must " +
                 "end with '_FK'. e.g. ORDER_CUSTOMER_FK"));
     }

--- a/src/test/java/com/wcg/liquibase/linters/AddPrimaryKeyChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/AddPrimaryKeyChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.AddPrimaryKeyChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class AddPrimaryKeyChangeLinterTest {
 
     private AddPrimaryKeyChangeLinter addPrimaryKeyChangeLinter;
@@ -32,58 +32,58 @@ class AddPrimaryKeyChangeLinterTest {
     }
 
     @Test
-    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddPrimaryKeyChange addPrimaryKeyChange = new AddPrimaryKeyChange();
         addPrimaryKeyChange.setChangeSet(changeSet);
         addPrimaryKeyChange.setTableName("TEST");
         addPrimaryKeyChange.setConstraintName("TEST_PK");
-        addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, config.getRules());
-        verify(objectNameLinter, times(1)).lintObjectNameLength("TEST_PK", addPrimaryKeyChange, config.getRules());
+        addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, ruleRunner);
+        verify(objectNameLinter, times(1)).lintObjectNameLength("TEST_PK", addPrimaryKeyChange, ruleRunner);
     }
 
     @DisplayName("Should validate name in incorrect format")
     @Test
-    void should_validate_name_in_incorrect_format(ChangeSet changeSet, Config config) {
+    void should_validate_name_in_incorrect_format(ChangeSet changeSet, RuleRunner ruleRunner) {
         AddPrimaryKeyChange addPrimaryKeyChange = new AddPrimaryKeyChange();
         addPrimaryKeyChange.setChangeSet(changeSet);
         addPrimaryKeyChange.setTableName("TEST");
         addPrimaryKeyChange.setConstraintName("TEST_PK_ABC");
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, ruleRunner));
         assertTrue(changeLogParseException.getMessage().contains("Primary key constraint '" + addPrimaryKeyChange.getConstraintName() + "' must end with '_PK' e.g. TABLE_PK"));
     }
 
     @DisplayName("Should validate name in correct format")
     @Test
-    void should_validate_name_in_correct_format(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_validate_name_in_correct_format(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddPrimaryKeyChange addPrimaryKeyChange = new AddPrimaryKeyChange();
         addPrimaryKeyChange.setChangeSet(changeSet);
         addPrimaryKeyChange.setTableName("TEST");
         addPrimaryKeyChange.setConstraintName("TEST_PK");
-        addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, config.getRules());
+        addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, ruleRunner);
     }
 
     @DisplayName("Should not validate if name in format is longer than max length")
     @Test
-    void should_not_validate_if_name_in_format_more_than_max_length(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_not_validate_if_name_in_format_more_than_max_length(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddPrimaryKeyChange addPrimaryKeyChange = new AddPrimaryKeyChange();
         addPrimaryKeyChange.setChangeSet(changeSet);
         addPrimaryKeyChange.setTableName("TEST_TEST_TEST_TEST_TEST_TEST");
         addPrimaryKeyChange.setConstraintName("INVALID_NAME_PK");
         changeSet.addChange(addPrimaryKeyChange);
-        addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, config.getRules());
+        addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, ruleRunner);
     }
 
     @DisplayName("Should not validate if name in format but validate ending when longer than max length")
     @Test
-    void should_not_validate_name_in_format_but_validate_ending_when_more_than_max_length(ChangeSet changeSet, Config config) {
+    void should_not_validate_name_in_format_but_validate_ending_when_more_than_max_length(ChangeSet changeSet, RuleRunner ruleRunner) {
         AddPrimaryKeyChange addPrimaryKeyChange = new AddPrimaryKeyChange();
         addPrimaryKeyChange.setChangeSet(changeSet);
         addPrimaryKeyChange.setTableName("TEST_TEST_TEST_TEST_TEST_TEST");
         addPrimaryKeyChange.setConstraintName("INVALID_NAME");
         changeSet.addChange(addPrimaryKeyChange);
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> addPrimaryKeyChangeLinter.lint(addPrimaryKeyChange, ruleRunner));
         assertTrue(changeLogParseException.getMessage().contains("Primary key constraint '" + addPrimaryKeyChange.getConstraintName() + "' must " +
                 "end with '_PK' e.g. TABLE_PK"));
     }

--- a/src/test/java/com/wcg/liquibase/linters/AddUniqueConstraintChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/AddUniqueConstraintChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.AddUniqueConstraintChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class AddUniqueConstraintChangeLinterTest {
 
     private AddUniqueConstraintChangeLinter addUniqueConstraintChangeLinter;
@@ -32,49 +32,49 @@ class AddUniqueConstraintChangeLinterTest {
     }
 
     @Test
-    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddUniqueConstraintChange constraintChangeValid = new AddUniqueConstraintChange();
         constraintChangeValid.setChangeSet(changeSet);
         constraintChangeValid.setTableName("TEST_TEST");
         constraintChangeValid.setConstraintName("TEST_TEST_U1");
         changeSet.addChange(constraintChangeValid);
-        addUniqueConstraintChangeLinter.lint(constraintChangeValid, config.getRules());
-        verify(objectNameLinter, times(1)).lintObjectNameLength("TEST_TEST_U1", constraintChangeValid, config.getRules());
+        addUniqueConstraintChangeLinter.lint(constraintChangeValid, ruleRunner);
+        verify(objectNameLinter, times(1)).lintObjectNameLength("TEST_TEST_U1", constraintChangeValid, ruleRunner);
     }
 
     @DisplayName("Should validate name in incorrect format")
     @Test
-    void should_validate_name_in_incorrect_format(ChangeSet changeSet, Config config) {
+    void should_validate_name_in_incorrect_format(ChangeSet changeSet, RuleRunner ruleRunner) {
         AddUniqueConstraintChange constraintChangeInvalid = new AddUniqueConstraintChange();
         constraintChangeInvalid.setChangeSet(changeSet);
         constraintChangeInvalid.setTableName("MAGIC");
         constraintChangeInvalid.setConstraintName("MAGIC");
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> addUniqueConstraintChangeLinter.lint(constraintChangeInvalid, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> addUniqueConstraintChangeLinter.lint(constraintChangeInvalid, ruleRunner));
         assertTrue(changeLogParseException.getMessage().contains("Unique constraint 'MAGIC' must follow pattern " +
                 "table name followed by 'U' and a number e.g. TABLE_U1"));
     }
 
     @DisplayName("Should validate name in correct format")
     @Test
-    void should_validate_name_in_correct_format(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_validate_name_in_correct_format(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddUniqueConstraintChange constraintChangeValid = new AddUniqueConstraintChange();
         constraintChangeValid.setChangeSet(changeSet);
         constraintChangeValid.setTableName("TEST_TEST");
         constraintChangeValid.setConstraintName("TEST_TEST_U1");
         changeSet.addChange(constraintChangeValid);
-        addUniqueConstraintChangeLinter.lint(constraintChangeValid, config.getRules());
+        addUniqueConstraintChangeLinter.lint(constraintChangeValid, ruleRunner);
     }
 
     @DisplayName("Should not validate if name in format is longer than max length")
     @Test
-    void should_not_validate_if_name_in_format_more_than_max_length(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_not_validate_if_name_in_format_more_than_max_length(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddUniqueConstraintChange constraintChange = new AddUniqueConstraintChange();
         constraintChange.setChangeSet(changeSet);
         constraintChange.setTableName("TEST_TEST_TEST_TEST_TEST_TEST");
         constraintChange.setConstraintName("INVALID_NAME");
         changeSet.addChange(constraintChange);
-        addUniqueConstraintChangeLinter.lint(constraintChange, config.getRules());
+        addUniqueConstraintChangeLinter.lint(constraintChange, ruleRunner);
     }
 
 }

--- a/src/test/java/com/wcg/liquibase/linters/ColumnConfigLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/ColumnConfigLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.AddColumnChangeParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.AddColumnConfig;
 import liquibase.change.ConstraintsConfig;
 import liquibase.change.core.AddColumnChange;
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith({AddColumnChangeParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({AddColumnChangeParameterResolver.class, RuleRunnerParameterResolver.class})
 class ColumnConfigLinterTest {
 
     private ColumnConfigLinter columnConfigLinter;
@@ -27,13 +27,13 @@ class ColumnConfigLinterTest {
 
     @DisplayName("Should not allow add column without remarks")
     @Test
-    void should_not_allow_add_column_without_remarks(AddColumnChange addColumnChange, Config config) {
+    void should_not_allow_add_column_without_remarks(AddColumnChange addColumnChange, RuleRunner ruleRunner) {
         AddColumnConfig addColumnConfig = new AddColumnConfig();
         addColumnConfig.setName("TEST");
         addColumnChange.addColumn(addColumnConfig);
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> columnConfigLinter.lintColumnConfig(addColumnChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> columnConfigLinter.lintColumnConfig(addColumnChange, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Add column must contain remarks"));
 
@@ -41,7 +41,7 @@ class ColumnConfigLinterTest {
 
     @DisplayName("Should allow add column with remarks")
     @Test
-    void should_allow_add_column_with_remarks_and_nullable(AddColumnChange addColumnChange, Config config) throws ChangeLogParseException {
+    void should_allow_add_column_with_remarks_and_nullable(AddColumnChange addColumnChange, RuleRunner ruleRunner) throws ChangeLogParseException {
         AddColumnConfig addColumnConfig = new AddColumnConfig();
         addColumnConfig.setName("TEST");
         addColumnConfig.setRemarks("REMARK");
@@ -50,12 +50,12 @@ class ColumnConfigLinterTest {
         addColumnConfig.setConstraints(constraints);
         addColumnChange.addColumn(addColumnConfig);
 
-        columnConfigLinter.lintColumnConfig(addColumnChange, config.getRules());
+        columnConfigLinter.lintColumnConfig(addColumnChange, ruleRunner);
     }
 
     @DisplayName("Should enforce use of nullable constraint")
     @Test
-    void should_enforce_use_of_nullable_constraint(AddColumnChange addColumnChange, Config config) {
+    void should_enforce_use_of_nullable_constraint(AddColumnChange addColumnChange, RuleRunner ruleRunner) {
         AddColumnConfig addColumnConfig = new AddColumnConfig();
         addColumnConfig.setName("TEST");
         addColumnConfig.setRemarks("REMARK");
@@ -64,14 +64,14 @@ class ColumnConfigLinterTest {
         addColumnChange.addColumn(addColumnConfig);
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> columnConfigLinter.lintColumnConfig(addColumnChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> columnConfigLinter.lintColumnConfig(addColumnChange, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Add column must specify nullable constraint"));
     }
 
     @DisplayName("Should not allow primary key attribute")
     @Test
-    void should_not_allow_primary_key_attribute(AddColumnChange addColumnChange, Config config) {
+    void should_not_allow_primary_key_attribute(AddColumnChange addColumnChange, RuleRunner ruleRunner) {
         AddColumnConfig addColumnConfig = new AddColumnConfig();
         addColumnConfig.setName("TEST");
         addColumnConfig.setRemarks("REMARK");
@@ -82,7 +82,7 @@ class ColumnConfigLinterTest {
         addColumnChange.addColumn(addColumnConfig);
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> columnConfigLinter.lintColumnConfig(addColumnChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> columnConfigLinter.lintColumnConfig(addColumnChange, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Add column must not use primary key attribute. Instead use AddPrimaryKey change type"));
     }

--- a/src/test/java/com/wcg/liquibase/linters/CreateIndexChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/CreateIndexChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.CreateIndexChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class CreateIndexChangeLinterTest {
 
     private CreateIndexChangeLinter createIndexChangeLinter;
@@ -32,84 +32,84 @@ class CreateIndexChangeLinterTest {
     }
 
     @Test
-    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         CreateIndexChange validChange = new CreateIndexChange();
         validChange.setChangeSet(changeSet);
         validChange.setTableName("TEST_TEST");
         validChange.setIndexName("TEST_TEST_I1");
         changeSet.addChange(validChange);
-        createIndexChangeLinter.lint(validChange, config.getRules());
-        verify(objectNameLinter, times(1)).lintObjectNameLength("TEST_TEST_I1", validChange, config.getRules());
+        createIndexChangeLinter.lint(validChange, ruleRunner);
+        verify(objectNameLinter, times(1)).lintObjectNameLength("TEST_TEST_I1", validChange, ruleRunner);
     }
 
     @DisplayName("Should reject name where prefix doesn't match table name")
     @Test
-    void should_validate_inconsistent_with_table_name(ChangeSet changeSet, Config config) {
+    void should_validate_inconsistent_with_table_name(ChangeSet changeSet, RuleRunner ruleRunner) {
         CreateIndexChange validChange = new CreateIndexChange();
         validChange.setChangeSet(changeSet);
         validChange.setTableName("TEST");
         validChange.setIndexName("TEST_TEST_I1");
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> createIndexChangeLinter.lint(validChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> createIndexChangeLinter.lint(validChange, ruleRunner));
         assertTrue(changeLogParseException.getMessage().contains("Index 'TEST_TEST_I1' must follow pattern " +
                 "table name followed by 'I' and a number e.g. APPLICATION_I1, or match a primary key or unique constraint name"));
     }
 
     @DisplayName("Should reject name where suffix isn't one of _PK, _Un or _In")
     @Test
-    void should_validate_unsuitable_suffix(ChangeSet changeSet, Config config) {
+    void should_validate_unsuitable_suffix(ChangeSet changeSet, RuleRunner ruleRunner) {
         CreateIndexChange validChange = new CreateIndexChange();
         validChange.setChangeSet(changeSet);
         validChange.setTableName("TEST_TEST");
         validChange.setIndexName("TEST_TEST_FOO");
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> createIndexChangeLinter.lint(validChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> createIndexChangeLinter.lint(validChange, ruleRunner));
         assertTrue(changeLogParseException.getMessage().contains("Index 'TEST_TEST_FOO' must follow pattern " +
                 "table name followed by 'I' and a number e.g. APPLICATION_I1, or match a primary key or unique constraint name"));
     }
 
     @DisplayName("Should validate name in correct format for misc index")
     @Test
-    void should_validate_name_in_correct_format_misc(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_validate_name_in_correct_format_misc(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         CreateIndexChange constraintChangeValid = new CreateIndexChange();
         constraintChangeValid.setChangeSet(changeSet);
         constraintChangeValid.setTableName("TEST_TEST");
         constraintChangeValid.setIndexName("TEST_TEST_I1");
         changeSet.addChange(constraintChangeValid);
-        createIndexChangeLinter.lint(constraintChangeValid, config.getRules());
+        createIndexChangeLinter.lint(constraintChangeValid, ruleRunner);
     }
 
     @DisplayName("Should validate name in correct format for unique constraint index")
     @Test
-    void should_validate_name_in_correct_format_unique(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_validate_name_in_correct_format_unique(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         CreateIndexChange constraintChangeValid = new CreateIndexChange();
         constraintChangeValid.setChangeSet(changeSet);
         constraintChangeValid.setTableName("TEST_TEST");
         constraintChangeValid.setIndexName("TEST_TEST_U1");
         changeSet.addChange(constraintChangeValid);
-        createIndexChangeLinter.lint(constraintChangeValid, config.getRules());
+        createIndexChangeLinter.lint(constraintChangeValid, ruleRunner);
     }
 
     @DisplayName("Should validate name in correct format for primary key index")
     @Test
-    void should_validate_name_in_correct_format_primary(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_validate_name_in_correct_format_primary(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         CreateIndexChange constraintChangeValid = new CreateIndexChange();
         constraintChangeValid.setChangeSet(changeSet);
         constraintChangeValid.setTableName("TEST_TEST");
         constraintChangeValid.setIndexName("TEST_TEST_PK");
         changeSet.addChange(constraintChangeValid);
-        createIndexChangeLinter.lint(constraintChangeValid, config.getRules());
+        createIndexChangeLinter.lint(constraintChangeValid, ruleRunner);
     }
 
     @DisplayName("Should not validate if name in format is longer than max length")
     @Test
-    void should_not_validate_if_name_in_format_more_than_max_length(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_not_validate_if_name_in_format_more_than_max_length(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         CreateIndexChange constraintChange = new CreateIndexChange();
         constraintChange.setChangeSet(changeSet);
         constraintChange.setTableName("TEST_TEST_TEST_TEST_TEST_TEST");
         constraintChange.setIndexName("INVALID_NAME");
         changeSet.addChange(constraintChange);
-        createIndexChangeLinter.lint(constraintChange, config.getRules());
+        createIndexChangeLinter.lint(constraintChange, ruleRunner);
     }
 
 }

--- a/src/test/java/com/wcg/liquibase/linters/CreateTableChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/CreateTableChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.CreateTableChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class CreateTableChangeLinterTest {
 
     private CreateTableChangeLinter createTableChangeLinter;
@@ -39,14 +39,14 @@ class CreateTableChangeLinterTest {
 
     @DisplayName("Should not allow create table without remarks attribute")
     @Test
-    void should_not_allow_add_column_without_remarks(ChangeSet changeSet, Config config) {
+    void should_not_allow_add_column_without_remarks(ChangeSet changeSet, RuleRunner ruleRunner) {
         CreateTableChange createTableChange = new CreateTableChange();
         createTableChange.setTableName("TEST");
         createTableChange.setChangeSet(changeSet);
         changeSet.addChange(createTableChange);
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> createTableChangeLinter.lint(createTableChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> createTableChangeLinter.lint(createTableChange, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Create table must contain remark attribute"));
 
@@ -54,25 +54,25 @@ class CreateTableChangeLinterTest {
 
     @DisplayName("Should allow create table with remarks attribute")
     @Test
-    void should_allow_add_column_with_remarks(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_allow_add_column_with_remarks(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         CreateTableChange createTableChange = new CreateTableChange();
         createTableChange.setTableName("TEST");
         createTableChange.setRemarks("REMARK");
         createTableChange.setChangeSet(changeSet);
         changeSet.addChange(createTableChange);
 
-        createTableChangeLinter.lint(createTableChange, config.getRules());
+        createTableChangeLinter.lint(createTableChange, ruleRunner);
     }
 
     @Test
-    void should_call_table_name_linter(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_call_table_name_linter(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         CreateTableChange createTableChange = new CreateTableChange();
         createTableChange.setTableName("TEST");
         createTableChange.setRemarks("REMARK");
         createTableChange.setChangeSet(changeSet);
         changeSet.addChange(createTableChange);
 
-        createTableChangeLinter.lint(createTableChange, config.getRules());
-        verify(tableNameLinter, times(1)).lintTableName("TEST", createTableChange, config.getRules());
+        createTableChangeLinter.lint(createTableChange, ruleRunner);
+        verify(tableNameLinter, times(1)).lintTableName("TEST", createTableChange, ruleRunner);
     }
 }

--- a/src/test/java/com/wcg/liquibase/linters/MergeColumnChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/MergeColumnChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.MergeColumnChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class MergeColumnChangeLinterTest {
 
     private MergeColumnChangeLinter mergeColumnChangeLinter;
@@ -29,12 +29,12 @@ class MergeColumnChangeLinterTest {
     }
 
     @Test
-    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         MergeColumnChange mergeColumnChange = new MergeColumnChange();
         mergeColumnChange.setChangeSet(changeSet);
         mergeColumnChange.setFinalColumnName("TEST_TEST");
         changeSet.addChange(mergeColumnChange);
-        mergeColumnChangeLinter.lint(mergeColumnChange, config.getRules());
-        verify(objectNameLinter, times(1)).lintObjectName("TEST_TEST", mergeColumnChange, config.getRules());
+        mergeColumnChangeLinter.lint(mergeColumnChange, ruleRunner);
+        verify(objectNameLinter, times(1)).lintObjectName("TEST_TEST", mergeColumnChange, ruleRunner);
     }
 }

--- a/src/test/java/com/wcg/liquibase/linters/ModifyDataChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/ModifyDataChangeLinterTest.java
@@ -1,9 +1,11 @@
 package com.wcg.liquibase.linters;
 
 import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.config.rules.RuleType;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
 import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.UpdateDataChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -14,7 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class, DefaultConfigParameterResolver.class})
 class ModifyDataChangeLinterTest {
 
     private ModifyDataChangeLinter modifyDataChangeLinter;
@@ -25,27 +27,27 @@ class ModifyDataChangeLinterTest {
     }
 
     @Test
-    void should_enforce_where_condition_on_certain_tables(ChangeSet changeSet, Config config) {
+    void should_enforce_where_condition_on_certain_tables(ChangeSet changeSet, Config config, RuleRunner ruleRunner) {
         for (String table : RuleType.MODIFY_DATA_ENFORCE_WHERE.create(config.getRules()).getRuleConfig().getRequireWhere()) {
             UpdateDataChange updateDataChange = new UpdateDataChange();
             updateDataChange.setTableName(table);
             updateDataChange.setChangeSet(changeSet);
 
             ChangeLogParseException changeLogParseException =
-                    assertThrows(ChangeLogParseException.class, () -> modifyDataChangeLinter.lint(updateDataChange, config.getRules()));
+                    assertThrows(ChangeLogParseException.class, () -> modifyDataChangeLinter.lint(updateDataChange, ruleRunner));
 
             assertTrue(changeLogParseException.getMessage().contains("Modify data on table '" + table + "' must have a where condition"));
         }
     }
 
     @Test
-    void should_not_allow_where_condition_to_start_with_where_case_insensitive(ChangeSet changeSet, Config config) {
+    void should_not_allow_where_condition_to_start_with_where_case_insensitive(ChangeSet changeSet, RuleRunner ruleRunner) {
         UpdateDataChange updateDataChange = new UpdateDataChange();
         updateDataChange.setTableName("TABLE");
         updateDataChange.setChangeSet(changeSet);
         updateDataChange.setWhere("WHERE table = 'X'");
         ChangeLogParseException changeLogParseException1 =
-                assertThrows(ChangeLogParseException.class, () -> modifyDataChangeLinter.lint(updateDataChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> modifyDataChangeLinter.lint(updateDataChange, ruleRunner));
 
         assertTrue(changeLogParseException1.getMessage().contains("Modify data where starts with where, that's probably a mistake"));
 
@@ -53,7 +55,7 @@ class ModifyDataChangeLinterTest {
         updateDataChange.setChangeSet(changeSet);
         updateDataChange.setWhere("where table = 'X'");
         ChangeLogParseException changeLogParseException2 =
-                assertThrows(ChangeLogParseException.class, () -> modifyDataChangeLinter.lint(updateDataChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> modifyDataChangeLinter.lint(updateDataChange, ruleRunner));
 
         assertTrue(changeLogParseException2.getMessage().contains("Modify data where starts with where, that's probably a mistake"));
     }

--- a/src/test/java/com/wcg/liquibase/linters/ObjectNameLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/ObjectNameLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.AddColumnChangeParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.AddColumnChange;
 import liquibase.exception.ChangeLogParseException;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +17,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith({AddColumnChangeParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({AddColumnChangeParameterResolver.class, RuleRunnerParameterResolver.class})
 class ObjectNameLinterTest {
 
     private ObjectNameLinter objectNameLinter;
@@ -29,56 +29,56 @@ class ObjectNameLinterTest {
 
     @DisplayName("Should only allow uppercase with _ separator")
     @Test
-    void should_only_allow_uppercase_with_underscore_separator(AddColumnChange addColumnChange, Config config) throws ChangeLogParseException {
+    void should_only_allow_uppercase_with_underscore_separator(AddColumnChange addColumnChange, RuleRunner ruleRunner) throws ChangeLogParseException {
         final List<String> invalidNames = Arrays.asList("_TEST", "TEST_", "TE ST", "TeST");
         for (String invalidName : invalidNames) {
             ChangeLogParseException changeLogParseException =
-                    assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectName(invalidName, addColumnChange, config.getRules()));
+                    assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectName(invalidName, addColumnChange, ruleRunner));
             assertTrue(changeLogParseException.getMessage().contains("Object name '" + invalidName + "' name must be uppercase and use '_' separation"));
         }
 
-        objectNameLinter.lintObjectName("VALID_NAME", addColumnChange, config.getRules());
+        objectNameLinter.lintObjectName("VALID_NAME", addColumnChange, ruleRunner);
     }
 
     @DisplayName("Should only allow names under max length")
     @Test
-    void should_only_allow_names_under_max_length(AddColumnChange addColumnChange, Config config) throws ChangeLogParseException {
+    void should_only_allow_names_under_max_length(AddColumnChange addColumnChange, RuleRunner ruleRunner) throws ChangeLogParseException {
         String tooLong = "TEST_TEST_TEST_TEST_TEST_TEST_TEST";
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectName(tooLong, addColumnChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectName(tooLong, addColumnChange, ruleRunner));
         assertTrue(changeLogParseException.getMessage().contains("Object name '" + tooLong + "' must be less than 30 characters"));
 
         String notTooLong = "TEST_TEST_TEST_TEST_TEST_TEST";
-        objectNameLinter.lintObjectName(notTooLong, addColumnChange, config.getRules());
+        objectNameLinter.lintObjectName(notTooLong, addColumnChange, ruleRunner);
     }
 
     @DisplayName("Should catch when name is null, when trying to lint length")
     @Test
-    void should_catch_null_names_when_checking_length(AddColumnChange addColumnChange, Config config) {
+    void should_catch_null_names_when_checking_length(AddColumnChange addColumnChange, RuleRunner ruleRunner) {
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectNameLength(null, addColumnChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectNameLength(null, addColumnChange, ruleRunner));
         assertTrue(changeLogParseException.getMessage().contains("Object name is null"));
     }
 
     @DisplayName("Should allow uppercase with, numbers and _ separator")
     @Test
-    void should_only_allow_uppercase_with_numbers_and_underscore_separator(AddColumnChange addColumnChange, Config config) throws ChangeLogParseException {
+    void should_only_allow_uppercase_with_numbers_and_underscore_separator(AddColumnChange addColumnChange, RuleRunner ruleRunner) throws ChangeLogParseException {
         final List<String> invalidNames = Arrays.asList("_TEST", "TEST_", "TE ST", "TeST");
         for (String invalidName : invalidNames) {
             ChangeLogParseException changeLogParseException =
-                    assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectName(invalidName, addColumnChange, config.getRules()));
+                    assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectName(invalidName, addColumnChange, ruleRunner));
             assertTrue(changeLogParseException.getMessage().contains("Object name '" + invalidName + "' name must be uppercase and use '_' separation"));
         }
-        objectNameLinter.lintObjectName("VALID_12_3NAME_99", addColumnChange, config.getRules());
+        objectNameLinter.lintObjectName("VALID_12_3NAME_99", addColumnChange, ruleRunner);
     }
 
     @DisplayName("Should allow uppercase with, numbers and _ separator")
     @Test
-    void should_not_allow_null_object_name(AddColumnChange addColumnChange, Config config) {
+    void should_not_allow_null_object_name(AddColumnChange addColumnChange, RuleRunner ruleRunner) {
         final List<String> invalidNames = Collections.singletonList(null);
         for (String invalidName : invalidNames) {
             ChangeLogParseException changeLogParseException =
-                    assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectName(invalidName, addColumnChange, config.getRules()));
+                    assertThrows(ChangeLogParseException.class, () -> objectNameLinter.lintObjectName(invalidName, addColumnChange, ruleRunner));
             assertTrue(changeLogParseException.getMessage().contains("Object name is null"));
         }
     }

--- a/src/test/java/com/wcg/liquibase/linters/RenameColumnChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/RenameColumnChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.RenameColumnChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class RenameColumnChangeLinterTest {
 
     private RenameColumnChangeLinter renameColumnChangeLinter;
@@ -29,12 +29,12 @@ class RenameColumnChangeLinterTest {
     }
 
     @Test
-    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         RenameColumnChange renameColumnChange = new RenameColumnChange();
         renameColumnChange.setChangeSet(changeSet);
         renameColumnChange.setNewColumnName("TEST_TEST");
         changeSet.addChange(renameColumnChange);
-        renameColumnChangeLinter.lint(renameColumnChange, config.getRules());
-        verify(objectNameLinter, times(1)).lintObjectName("TEST_TEST", renameColumnChange, config.getRules());
+        renameColumnChangeLinter.lint(renameColumnChange, ruleRunner);
+        verify(objectNameLinter, times(1)).lintObjectName("TEST_TEST", renameColumnChange, ruleRunner);
     }
 }

--- a/src/test/java/com/wcg/liquibase/linters/RenameTableChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/RenameTableChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.RenameTableChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class RenameTableChangeLinterTest {
 
     private RenameTableChangeLinter renameTableChangeLinter;
@@ -29,14 +29,14 @@ class RenameTableChangeLinterTest {
     }
 
     @Test
-    void should_call_table_name_linter(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_call_table_name_linter(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         RenameTableChange renameTableChange = new RenameTableChange();
         renameTableChange.setNewTableName("TEST");
         renameTableChange.setChangeSet(changeSet);
         changeSet.addChange(renameTableChange);
 
-        renameTableChangeLinter.lint(renameTableChange, config.getRules());
-        verify(tableNameLinter, times(1)).lintTableName("TEST", renameTableChange, config.getRules());
+        renameTableChangeLinter.lint(renameTableChange, ruleRunner);
+        verify(tableNameLinter, times(1)).lintTableName("TEST", renameTableChange, ruleRunner);
     }
 
 }

--- a/src/test/java/com/wcg/liquibase/linters/RenameViewChangeLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/RenameViewChangeLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.RenameViewChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.mockito.Mockito.*;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class RenameViewChangeLinterTest {
 
     private RenameViewChangeLinter renameViewChangeLinter;
@@ -29,12 +29,12 @@ class RenameViewChangeLinterTest {
     }
 
     @Test
-    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_use_object_name_linter_for_name_length_check(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         RenameViewChange renameViewChange = new RenameViewChange();
         renameViewChange.setChangeSet(changeSet);
         renameViewChange.setNewViewName("TEST_TEST");
         changeSet.addChange(renameViewChange);
-        renameViewChangeLinter.lint(renameViewChange, config.getRules());
-        verify(objectNameLinter, times(1)).lintObjectNameLength("TEST_TEST", renameViewChange, config.getRules());
+        renameViewChangeLinter.lint(renameViewChange, ruleRunner);
+        verify(objectNameLinter, times(1)).lintObjectNameLength("TEST_TEST", renameViewChange, ruleRunner);
     }
 }

--- a/src/test/java/com/wcg/liquibase/linters/TableNameLinterTest.java
+++ b/src/test/java/com/wcg/liquibase/linters/TableNameLinterTest.java
@@ -1,8 +1,8 @@
 package com.wcg.liquibase.linters;
 
-import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
 import com.wcg.liquibase.resolvers.ChangeSetParameterResolver;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.change.core.CreateTableChange;
 import liquibase.changelog.ChangeSet;
 import liquibase.exception.ChangeLogParseException;
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith({ChangeSetParameterResolver.class, DefaultConfigParameterResolver.class})
+@ExtendWith({ChangeSetParameterResolver.class, RuleRunnerParameterResolver.class})
 class TableNameLinterTest {
 
     private TableNameLinter tableNameLinter;
@@ -26,7 +26,7 @@ class TableNameLinterTest {
 
     @DisplayName("Should not allow table name starting with tbl")
     @Test
-    void should_not_allow_table_name_starting_with_tbl(ChangeSet changeSet, Config config) {
+    void should_not_allow_table_name_starting_with_tbl(ChangeSet changeSet, RuleRunner ruleRunner) {
         CreateTableChange createTableChange = new CreateTableChange();
         createTableChange.setTableName("TBL_TEST");
         createTableChange.setRemarks("REMARK");
@@ -34,14 +34,14 @@ class TableNameLinterTest {
         changeSet.addChange(createTableChange);
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> tableNameLinter.lintTableName("TBL_TEST", createTableChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> tableNameLinter.lintTableName("TBL_TEST", createTableChange, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Table 'TBL_TEST' name must be uppercase, use '_' separation and not start with TBL"));
     }
 
     @DisplayName("Should not allow table name exceeding max length")
     @Test
-    void should_not_allow_table_name_exceeding_max_length(ChangeSet changeSet, Config config) {
+    void should_not_allow_table_name_exceeding_max_length(ChangeSet changeSet, RuleRunner ruleRunner) {
         CreateTableChange createTableChange = new CreateTableChange();
         createTableChange.setTableName("TEST_TEST_TEST_TEST_TEST_TEST");
         createTableChange.setRemarks("REMARK");
@@ -49,14 +49,14 @@ class TableNameLinterTest {
         changeSet.addChange(createTableChange);
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> tableNameLinter.lintTableName("TEST_TEST_TEST_TEST_TEST_TEST", createTableChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> tableNameLinter.lintTableName("TEST_TEST_TEST_TEST_TEST_TEST", createTableChange, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Table 'TEST_TEST_TEST_TEST_TEST_TEST' name must not be longer than " + 26));
     }
 
     @DisplayName("Should not allow table name exceeding max length")
     @Test
-    void should_not_allow_lower_case_table_name(ChangeSet changeSet, Config config) {
+    void should_not_allow_lower_case_table_name(ChangeSet changeSet, RuleRunner ruleRunner) {
         CreateTableChange createTableChange = new CreateTableChange();
         createTableChange.setTableName("test_table");
         createTableChange.setRemarks("REMARK");
@@ -64,7 +64,7 @@ class TableNameLinterTest {
         changeSet.addChange(createTableChange);
 
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> tableNameLinter.lintTableName("test_table", createTableChange, config.getRules()));
+                assertThrows(ChangeLogParseException.class, () -> tableNameLinter.lintTableName("test_table", createTableChange, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Table 'test_table' name must be uppercase, use '_' separation and not start with TBL"));
     }
@@ -72,13 +72,13 @@ class TableNameLinterTest {
 
     @DisplayName("Should allow valid table name")
     @Test
-    void should_allow_valid_table_name(ChangeSet changeSet, Config config) throws ChangeLogParseException {
+    void should_allow_valid_table_name(ChangeSet changeSet, RuleRunner ruleRunner) throws ChangeLogParseException {
         CreateTableChange createTableChange = new CreateTableChange();
         createTableChange.setTableName("TEST_TABLE_NAME");
         createTableChange.setRemarks("REMARK");
         createTableChange.setChangeSet(changeSet);
         changeSet.addChange(createTableChange);
 
-        tableNameLinter.lintTableName("TEST_TABLE_NAME", createTableChange, config.getRules());
+        tableNameLinter.lintTableName("TEST_TABLE_NAME", createTableChange, ruleRunner);
     }
 }

--- a/src/test/java/com/wcg/liquibase/resolvers/RuleRunnerParameterResolver.java
+++ b/src/test/java/com/wcg/liquibase/resolvers/RuleRunnerParameterResolver.java
@@ -1,0 +1,35 @@
+package com.wcg.liquibase.resolvers;
+
+import com.wcg.liquibase.config.Config;
+import com.wcg.liquibase.config.rules.RuleRunner;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class RuleRunnerParameterResolver implements ParameterResolver {
+
+    private final RuleRunner ruleRunner;
+
+    public RuleRunnerParameterResolver() {
+        try (InputStream inputStream = getClass().getResourceAsStream("/lqllint.test.json")) {
+            this.ruleRunner = new RuleRunner(Config.fromInputStream(inputStream).getRules());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load test lq lint default config file", e);
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == RuleRunner.class;
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return ruleRunner;
+    }
+
+}

--- a/src/test/java/liquibase/parser/ext/CustomChangeLogParserTest.java
+++ b/src/test/java/liquibase/parser/ext/CustomChangeLogParserTest.java
@@ -1,7 +1,7 @@
 package liquibase.parser.ext;
 
-import com.wcg.liquibase.config.Config;
-import com.wcg.liquibase.resolvers.DefaultConfigParameterResolver;
+import com.wcg.liquibase.config.rules.RuleRunner;
+import com.wcg.liquibase.resolvers.RuleRunnerParameterResolver;
 import liquibase.exception.ChangeLogParseException;
 import liquibase.parser.core.ParsedNode;
 import org.junit.jupiter.api.Test;
@@ -12,22 +12,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(DefaultConfigParameterResolver.class)
+@ExtendWith(RuleRunnerParameterResolver.class)
 public class CustomChangeLogParserTest {
 
     @Test
-    void should_allow_token_schema_name(Config config) throws ChangeLogParseException {
+    void should_allow_token_schema_name(RuleRunner ruleRunner) throws ChangeLogParseException {
         CustomChangeLogParser customChangeLogParser = new CustomChangeLogParser();
         ParsedNode parsedNode = mockParsedNode("${schema_name}");
-        customChangeLogParser.checkSchemaName(parsedNode, config);
+        customChangeLogParser.checkSchemaName(parsedNode, ruleRunner);
     }
 
     @Test
-    void should_not_allow_raw_schema_name(Config config) {
+    void should_not_allow_raw_schema_name(RuleRunner ruleRunner) {
         CustomChangeLogParser customChangeLogParser = new CustomChangeLogParser();
         ParsedNode parsedNode = mockParsedNode("SCHEMA_NAME");
         ChangeLogParseException changeLogParseException =
-                assertThrows(ChangeLogParseException.class, () -> customChangeLogParser.checkSchemaName(parsedNode, config));
+                assertThrows(ChangeLogParseException.class, () -> customChangeLogParser.checkSchemaName(parsedNode, ruleRunner));
 
         assertTrue(changeLogParseException.getMessage().contains("Must use schema name token, not SCHEMA_NAME"));
     }


### PR DESCRIPTION
Small tidy up so linters are passed the rule runner which contains the config rather than getting passed the config map itself.

Also changed CustomChangeLogParser so that it only loads the config once using the same pattern as  CustomXMLChangeLogSAXParser