### PR TITLE
Illegal change types

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ This will be picked up by the linter and override any default rules.
   "ignore-context-pattern": "^baseline.*$",
   "rules": {
   
-  }
+  },
+  "illegal-change-types": [
+      "liquibase.change.core.LoadDataChange"
+  ]
 }
 ```
 
@@ -239,6 +242,9 @@ Note: all rules are disabled by default
 
 #### Context ignore pattern
 If there is a set of changes that you always want ignored based on their context you can configure this using `ignore-context-pattern`.
+
+#### Illegal change types
+If there are a set of changes types that you don't want to allow in your project then you can specify an array of fully qualified classes using `illegal-change-types`. An error will be thrown if any of these change types are used. 
 
 #### Skipping a changeSet
 Sometimes you might have to do some less-than-ideal stuff to solve a particular problem, in a way that might contravene your normal lint rules. In these cases, if your `<comment>` includes the string "lqlint-ignore", then the linter will not enforce any rules on that changeSet.

--- a/src/main/java/com/wcg/liquibase/ChangeLogLinter.java
+++ b/src/main/java/com/wcg/liquibase/ChangeLogLinter.java
@@ -96,10 +96,9 @@ public class ChangeLogLinter {
 
     private void isIllegalChangeType(Config config, Change change) throws ChangeLogParseException {
         if (config.getIllegalChangeTypes() != null) {
-            final String changeType = change.getClass().getName();
-            for (String illegal : config.getIllegalChangeTypes()) {
-                if (changeType.endsWith(illegal)) {
-                    final String errorMessage = String.format("Change type '%s' is not allowed in this project", illegal);
+            for (Class illegal : config.getIllegalChangeTypes()) {
+                if (change.getClass() == illegal) {
+                    final String errorMessage = String.format("Change type '%s' is not allowed in this project", illegal.getCanonicalName());
                     throw ChangeLogParseExceptionHelper.build(change.getChangeSet().getChangeLog(), change, errorMessage);
                 }
             }

--- a/src/main/java/com/wcg/liquibase/ChangeLogLinter.java
+++ b/src/main/java/com/wcg/liquibase/ChangeLogLinter.java
@@ -84,10 +84,10 @@ public class ChangeLogLinter {
                     .run(RuleType.ISOLATE_DDL_CHANGES, changes);
 
             for (Change change : changes) {
+                isIllegalChangeType(config, change);
                 ruleRunner.forChange(change)
                         .run(RuleType.VALID_CONTEXT, contexts)
                         .run(RuleType.SEPARATE_DDL_CONTEXT, contexts);
-                isIllegalChangeType(config, change);
                 lint(change, ruleRunner);
             }
 

--- a/src/main/java/com/wcg/liquibase/config/Config.java
+++ b/src/main/java/com/wcg/liquibase/config/Config.java
@@ -26,12 +26,12 @@ public class Config {
     private final Pattern ignoreContextPattern;
     @JsonDeserialize(using = RuleConfigDeserializer.class)
     private final Map<String, RuleConfig> rules;
-    private final List<String> illegalChangeTypes;
+    private final List<Class> illegalChangeTypes;
 
     @JsonCreator
     public Config(@JsonProperty("ignore-context-pattern") String ignoreContextPatternString,
                   @JsonProperty("rules") Map<String, RuleConfig> rules,
-                  @JsonProperty("illegal-change-types") List<String> illegalChangeTypes) {
+                  @JsonProperty("illegal-change-types") List<Class> illegalChangeTypes) {
         this.ignoreContextPattern = ignoreContextPatternString != null ? Pattern.compile(ignoreContextPatternString) : null;
         this.rules = rules;
         this.illegalChangeTypes = illegalChangeTypes;
@@ -49,7 +49,7 @@ public class Config {
         return rules;
     }
 
-    public List<String> getIllegalChangeTypes() {
+    public List<Class> getIllegalChangeTypes() {
         return illegalChangeTypes;
     }
 

--- a/src/main/java/com/wcg/liquibase/config/Config.java
+++ b/src/main/java/com/wcg/liquibase/config/Config.java
@@ -16,6 +16,7 @@ import com.wcg.liquibase.config.rules.RuleRunner;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -25,11 +26,15 @@ public class Config {
     private final Pattern ignoreContextPattern;
     @JsonDeserialize(using = RuleConfigDeserializer.class)
     private final Map<String, RuleConfig> rules;
+    private final List<String> illegalChangeTypes;
 
     @JsonCreator
-    public Config(@JsonProperty("ignore-context-pattern") String ignoreContextPatternString, @JsonProperty("rules") Map<String, RuleConfig> rules) {
+    public Config(@JsonProperty("ignore-context-pattern") String ignoreContextPatternString,
+                  @JsonProperty("rules") Map<String, RuleConfig> rules,
+                  @JsonProperty("illegal-change-types") List<String> illegalChangeTypes) {
         this.ignoreContextPattern = ignoreContextPatternString != null ? Pattern.compile(ignoreContextPatternString) : null;
         this.rules = rules;
+        this.illegalChangeTypes = illegalChangeTypes;
     }
 
     public static Config fromInputStream(final InputStream inputStream) throws IOException {
@@ -42,6 +47,10 @@ public class Config {
 
     public Map<String, RuleConfig> getRules() {
         return rules;
+    }
+
+    public List<String> getIllegalChangeTypes() {
+        return illegalChangeTypes;
     }
 
     public RuleRunner getRuleRunner() {

--- a/src/test/java/com/wcg/liquibase/integration/IllegalChangeTypesIntegrationTest.java
+++ b/src/test/java/com/wcg/liquibase/integration/IllegalChangeTypesIntegrationTest.java
@@ -15,7 +15,7 @@ class IllegalChangeTypesIntegrationTest extends LinterIntegrationTest {
                 "Should not allow a illegal change type",
                 "illegal-change-types.xml",
                 "illegal-change-types.json",
-                "Change type 'LoadDataChange' is not allowed in this project");
+                "Change type 'liquibase.change.core.LoadDataChange' is not allowed in this project");
 
         return Collections.singletonList(test1);
     }

--- a/src/test/java/com/wcg/liquibase/integration/IllegalChangeTypesIntegrationTest.java
+++ b/src/test/java/com/wcg/liquibase/integration/IllegalChangeTypesIntegrationTest.java
@@ -1,0 +1,23 @@
+package com.wcg.liquibase.integration;
+
+import com.wcg.liquibase.resolvers.LiquibaseIntegrationTestResolver;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Collections;
+import java.util.List;
+
+@ExtendWith(LiquibaseIntegrationTestResolver.class)
+class IllegalChangeTypesIntegrationTest extends LinterIntegrationTest {
+
+    @Override
+    List<IntegrationTestConfig> getTests() {
+        IntegrationTestConfig test1 = IntegrationTestConfig.shouldFail(
+                "Should not allow a illegal change type",
+                "illegal-change-types.xml",
+                "illegal-change-types.json",
+                "Change type 'LoadDataChange' is not allowed in this project");
+
+        return Collections.singletonList(test1);
+    }
+
+}

--- a/src/test/resources/integration/illegal-change-types.csv
+++ b/src/test/resources/integration/illegal-change-types.csv
@@ -1,0 +1,1 @@
+abc,abc,abc

--- a/src/test/resources/integration/illegal-change-types.json
+++ b/src/test/resources/integration/illegal-change-types.json
@@ -1,6 +1,6 @@
 {
   "rules": {},
   "illegal-change-types": [
-    "LoadDataChange"
+    "liquibase.change.core.LoadDataChange"
   ]
 }

--- a/src/test/resources/integration/illegal-change-types.json
+++ b/src/test/resources/integration/illegal-change-types.json
@@ -1,0 +1,6 @@
+{
+  "rules": {},
+  "illegal-change-types": [
+    "LoadDataChange"
+  ]
+}

--- a/src/test/resources/integration/illegal-change-types.xml
+++ b/src/test/resources/integration/illegal-change-types.xml
@@ -1,0 +1,11 @@
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="201809011238" author="luke.rogers">
+        <loadData tableName="TEST"
+                  file="src/test/resources/integration/illegal-change-types.csv"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
In some projects you may not want to allow certain change types. A good of example of this would be [LoadData](https://www.liquibase.org/documentation/changes/load_data.html), where you can load data using a csv file. This allows you to define change types which you wish to ban in the project. 

We use class type which requires fully qualified class name. Chose not to create a clever custom deserialiser here that would add Liquibase package to start automatically because its possible to [create custom change types](http://www.liquibase.org/documentation/changes/custom_change.html).