### PR TITLE
Support using tag name in illegal change type rule config

### DIFF
--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/specific/IllegalChangeTypes.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/specific/IllegalChangeTypes.java
@@ -16,7 +16,7 @@ public class IllegalChangeTypes extends Rule<Change> implements WithFormattedErr
     public boolean invalid(Change change, Change sameChange) {
         if (getRuleConfig().getValues() != null) {
             return getRuleConfig().getValues().stream()
-                    .anyMatch(illegal -> getChangeClassName(change).equals(illegal) || getChangeName(change).equals(illegal));
+                    .anyMatch(illegal -> getChangeName(change).equals(illegal) || getChangeClassName(change).equals(illegal));
         }
         return false;
     }

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/specific/IllegalChangeTypes.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/specific/IllegalChangeTypes.java
@@ -4,6 +4,7 @@ import com.whiteclarkegroup.liquibaselinter.config.rules.Rule;
 import com.whiteclarkegroup.liquibaselinter.config.rules.RuleConfig;
 import com.whiteclarkegroup.liquibaselinter.config.rules.WithFormattedErrorMessage;
 import liquibase.change.Change;
+import liquibase.change.DatabaseChange;
 
 public class IllegalChangeTypes extends Rule<Change> implements WithFormattedErrorMessage<Change> {
 
@@ -14,13 +15,18 @@ public class IllegalChangeTypes extends Rule<Change> implements WithFormattedErr
     @Override
     public boolean invalid(Change change, Change sameChange) {
         if (getRuleConfig().getValues() != null) {
-            for (String illegal : getRuleConfig().getValues()) {
-                if (change.getClass().getName().equals(illegal)) {
-                    return true;
-                }
-            }
+            return getRuleConfig().getValues().stream()
+                    .anyMatch(illegal -> getChangeClassName(change).equals(illegal) || getChangeName(change).equals(illegal));
         }
         return false;
+    }
+
+    private String getChangeClassName(Change change) {
+        return change.getClass().getName();
+    }
+
+    private String getChangeName(Change change) {
+        return change.getClass().getAnnotation(DatabaseChange.class).name();
     }
 
     @Override

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/specific/IllegalChangeTypesTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/specific/IllegalChangeTypesTest.java
@@ -1,6 +1,7 @@
 package com.whiteclarkegroup.liquibaselinter.config.rules.specific;
 
 import com.whiteclarkegroup.liquibaselinter.config.rules.RuleConfig;
+import liquibase.change.DatabaseChange;
 import liquibase.change.core.LoadDataChange;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,13 @@ class IllegalChangeTypesTest {
     @Test
     void illegalChangeTypeShouldBeInvalid() {
         IllegalChangeTypes illegalChangeTypes = new IllegalChangeTypes(RuleConfig.builder().withValues(Collections.singletonList("liquibase.change.core.LoadDataChange")).build());
+        assertTrue(illegalChangeTypes.invalid(new LoadDataChange(), null));
+    }
+
+    @DisplayName("Illegal change type from database change annotation name")
+    @Test
+    void illegalChangeTypeFromDatabaseChangeAnnotationName() {
+        IllegalChangeTypes illegalChangeTypes = new IllegalChangeTypes(RuleConfig.builder().withValues(Collections.singletonList(LoadDataChange.class.getAnnotation(DatabaseChange.class).name())).build());
         assertTrue(illegalChangeTypes.invalid(new LoadDataChange(), null));
     }
 

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/IllegalChangeTypesIntegrationTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/IllegalChangeTypesIntegrationTest.java
@@ -3,7 +3,7 @@ package com.whiteclarkegroup.liquibaselinter.integration;
 import com.whiteclarkegroup.liquibaselinter.resolvers.LiquibaseIntegrationTestResolver;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 @ExtendWith(LiquibaseIntegrationTestResolver.class)
@@ -17,7 +17,13 @@ class IllegalChangeTypesIntegrationTest extends LinterIntegrationTest {
                 "illegal-change-types.json",
                 "Change type 'liquibase.change.core.LoadDataChange' is not allowed in this project");
 
-        return Collections.singletonList(test1);
+        IntegrationTestConfig test2 = IntegrationTestConfig.shouldFail(
+                "Should not allow a illegal change type simple",
+                "illegal-change-types.xml",
+                "illegal-change-types-simple.json",
+                "Change type 'liquibase.change.core.LoadDataChange' is not allowed in this project");
+
+        return Arrays.asList(test1, test2);
     }
 
 }

--- a/src/test/resources/integration/illegal-change-types-simple.json
+++ b/src/test/resources/integration/illegal-change-types-simple.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "illegal-change-types": {
+      "values": [
+        "loadData"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
#13

This is easily possible by using the name property of the `@DatabaseChange` annotation which is present on all change types
 