### PR TITLE
Specific rule ignore

### DIFF
--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinter.java
@@ -14,7 +14,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 public class ChangeLogLinter {
 
@@ -59,7 +58,6 @@ public class ChangeLogLinter {
                     .add(LoadDataChange.class)
                     .add(LoadUpdateDataChange.class)
                     .build();
-    private static final Pattern LINT_IGNORE = Pattern.compile(".*lql-ignore.*");
 
     @SuppressWarnings("unchecked")
     public void lintChangeLog(final DatabaseChangeLog databaseChangeLog, Config config, RuleRunner ruleRunner) throws ChangeLogParseException {
@@ -118,7 +116,7 @@ public class ChangeLogLinter {
     }
 
     private boolean hasIgnoreComment(ChangeSet changeSet) {
-        return changeSet.getComments() != null && LINT_IGNORE.matcher(changeSet.getComments()).matches();
+        return changeSet.getComments() != null && changeSet.getComments().endsWith("lql-ignore");
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
@@ -31,6 +31,7 @@ public class RuleRunner {
 
     public static class RunningContext {
 
+        private static final String LQL_IGNORE_TOKEN = "lql-ignore:";
         private final Map<String, RuleConfig> ruleConfigs;
         private final Change change;
         private final DatabaseChangeLog databaseChangeLog;
@@ -67,11 +68,11 @@ public class RuleRunner {
         }
 
         private boolean isIgnored(RuleType ruleType) {
-            if (change == null || change.getChangeSet().getComments() == null || !change.getChangeSet().getComments().contains("lql-ignore:")) {
+            if (change == null || change.getChangeSet().getComments() == null || !change.getChangeSet().getComments().contains(LQL_IGNORE_TOKEN)) {
                 return false;
             }
             final String comments = change.getChangeSet().getComments();
-            final String toIgnore = comments.substring(comments.indexOf("lql-ignore:") + 11);
+            final String toIgnore = comments.substring(comments.indexOf(LQL_IGNORE_TOKEN) + LQL_IGNORE_TOKEN.length());
             final String[] split = toIgnore.split(",");
             return Arrays.stream(split).anyMatch(key -> ruleType.getKey().equalsIgnoreCase(key));
         }

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
@@ -42,6 +42,7 @@ public class RuleRunner {
             this.databaseChangeLog = databaseChangeLog;
         }
 
+        @SuppressWarnings("unchecked")
         public RunningContext run(RuleType ruleType, Object object) throws ChangeLogParseException {
             final Optional<Rule> optionalRule = ruleType.create(ruleConfigs);
             if (optionalRule.isPresent()) {

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
@@ -2,10 +2,10 @@ package com.whiteclarkegroup.liquibaselinter.config.rules;
 
 import com.whiteclarkegroup.liquibaselinter.ChangeLogParseExceptionHelper;
 import liquibase.change.Change;
-import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.exception.ChangeLogParseException;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -71,14 +71,9 @@ public class RuleRunner {
                 return false;
             }
             final String comments = change.getChangeSet().getComments();
-            final String toIgnore = comments.substring(comments.indexOf("lql-ignore:"));
+            final String toIgnore = comments.substring(comments.indexOf("lql-ignore:") + 11);
             final String[] split = toIgnore.split(",");
-            for (String key : split) {
-                if (ruleType.getKey().equalsIgnoreCase(key)) {
-                    return true;
-                }
-            }
-            return false;
+            return Arrays.stream(split).anyMatch(key -> ruleType.getKey().equalsIgnoreCase(key));
         }
 
     }

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
@@ -2,6 +2,7 @@ package com.whiteclarkegroup.liquibaselinter.config.rules;
 
 import com.whiteclarkegroup.liquibaselinter.ChangeLogParseExceptionHelper;
 import liquibase.change.Change;
+import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.exception.ChangeLogParseException;
 
@@ -44,7 +45,7 @@ public class RuleRunner {
             final Optional<Rule> optionalRule = ruleType.create(ruleConfigs);
             if (optionalRule.isPresent()) {
                 Rule rule = optionalRule.get();
-                if (shouldApply(rule, change) && rule.invalid(object, change)) {
+                if (shouldApply(ruleType, rule, change) && rule.invalid(object, change)) {
                     String errorMessage = Optional.ofNullable(rule.getErrorMessage()).orElse(ruleType.getDefaultErrorMessage());
                     if (rule instanceof WithFormattedErrorMessage) {
                         errorMessage = ((WithFormattedErrorMessage) rule).formatErrorMessage(errorMessage, object);
@@ -55,14 +56,29 @@ public class RuleRunner {
             return this;
         }
 
-        private boolean shouldApply(Rule rule, Change change) {
-            return rule.getRuleConfig().isEnabled() && evaluateCondition(rule, change);
+        private boolean shouldApply(RuleType ruleType, Rule rule, Change change) {
+            return rule.getRuleConfig().isEnabled() && evaluateCondition(rule, change) && !isIgnored(ruleType);
         }
 
         private boolean evaluateCondition(Rule rule, Change change) {
             return rule.getRuleConfig().getConditionalExpression()
                     .map(expression -> expression.getValue(change, boolean.class))
                     .orElse(true);
+        }
+
+        private boolean isIgnored(RuleType ruleType) {
+            if (change == null || change.getChangeSet().getComments() == null || !change.getChangeSet().getComments().contains("lql-ignore:")) {
+                return false;
+            }
+            final String comments = change.getChangeSet().getComments();
+            final String toIgnore = comments.substring(comments.indexOf("lql-ignore:"));
+            final String[] split = toIgnore.split(",");
+            for (String key : split) {
+                if (ruleType.getKey().equalsIgnoreCase(key)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
     }

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinterTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinterTest.java
@@ -60,7 +60,7 @@ class ChangeLogLinterTest {
     @Test
     void shouldNotLintChangeSetsWithLintDisabledComment(Config config, RuleRunner ruleRunner) throws ChangeLogParseException {
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
-        ChangeSet changeSet = getChangeSet(databaseChangeLog, null, "comment includes lql-ignore foo");
+        ChangeSet changeSet = getChangeSet(databaseChangeLog, null, "comment includes lql-ignore");
         changeLogLinter.lintChangeLog(databaseChangeLog, config, ruleRunner);
         verify(changeSet, never()).getChanges();
     }

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
@@ -1,0 +1,39 @@
+package com.whiteclarkegroup.liquibaselinter.config.rules;
+
+import com.google.common.collect.ImmutableMap;
+import liquibase.change.Change;
+import liquibase.exception.ChangeLogParseException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+class RuleRunnerTest {
+
+    @DisplayName("Should support ignoring specific rule types")
+    @Test
+    void shouldSupportSpecificRuleTypeIgnore() throws ChangeLogParseException {
+        RuleRunner ruleRunner = getRuleRunner();
+        ruleRunner.forChange(mockChange("Test comment lql-ignore:schema-name,table-name")).run(RuleType.TABLE_NAME, "TBL_TEST");
+
+        ChangeLogParseException changeLogParseException =
+                assertThrows(ChangeLogParseException.class, () -> ruleRunner.forChange(mockChange(null)).run(RuleType.TABLE_NAME, "TBL_TEST"));
+
+        assertTrue(changeLogParseException.getMessage().contains("Message: Table name does not follow pattern"));
+    }
+
+    private RuleRunner getRuleRunner() {
+        final ImmutableMap<String, RuleConfig> ruleConfigMap = ImmutableMap.of(RuleType.TABLE_NAME.getKey(), RuleConfig.builder().withEnabled(true).withPattern("^(?!TBL)[A-Z_]+(?<!_)$").build());
+        return new RuleRunner(ruleConfigMap);
+    }
+
+    private Change mockChange(String changeComment) {
+        Change change = mock(Change.class, RETURNS_DEEP_STUBS);
+        when(change.getChangeSet().getComments()).thenReturn(changeComment);
+        return change;
+    }
+
+}

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/SpecificRuleIgnoreIntegrationTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/SpecificRuleIgnoreIntegrationTest.java
@@ -1,0 +1,23 @@
+package com.whiteclarkegroup.liquibaselinter.integration;
+
+import com.whiteclarkegroup.liquibaselinter.resolvers.LiquibaseIntegrationTestResolver;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@ExtendWith(LiquibaseIntegrationTestResolver.class)
+class SpecificRuleIgnoreIntegrationTest extends LinterIntegrationTest {
+
+    @Override
+    List<IntegrationTestConfig> getTests() {
+        IntegrationTestConfig test1 = IntegrationTestConfig.shouldPass(
+                "Should be allowed to ignore specific rules",
+                "specific-rule-ignore.xml",
+                "specific-rule-ignore.json");
+
+        return Collections.singletonList(test1);
+    }
+
+}

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/SpecificRuleIgnoreIntegrationTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/SpecificRuleIgnoreIntegrationTest.java
@@ -3,7 +3,6 @@ package com.whiteclarkegroup.liquibaselinter.integration;
 import com.whiteclarkegroup.liquibaselinter.resolvers.LiquibaseIntegrationTestResolver;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/test/resources/integration/specific-rule-ignore.json
+++ b/src/test/resources/integration/specific-rule-ignore.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "table-name-length": {
+      "enabled": true,
+      "maxLength": 10
+    }
+  }
+}

--- a/src/test/resources/integration/specific-rule-ignore.xml
+++ b/src/test/resources/integration/specific-rule-ignore.xml
@@ -1,0 +1,12 @@
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="201809061558" author="luke.rogers">
+        <createTable tableName="THIS_NAME_SHOULD_BE_TOO_LONG">
+            <column name="TEST" type="VARCHAR(10)"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/integration/specific-rule-ignore.xml
+++ b/src/test/resources/integration/specific-rule-ignore.xml
@@ -4,6 +4,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
     <changeSet id="201809061558" author="luke.rogers">
+        <comment>lql-ignore:table-name-length</comment>
         <createTable tableName="THIS_NAME_SHOULD_BE_TOO_LONG">
             <column name="TEST" type="VARCHAR(10)"/>
         </createTable>


### PR DESCRIPTION
#16 

Support for ignoring specific rules. For a full ignore on a change the comment must end with `lql-ignore`. To ignore specific rules the comment must end with `lql-ignore:` followed by a comma separated list of rule keys to ignore