### PR TITLE
Add multiple jdk to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: java
+jdk:
+- oraclejdk8
+- oraclejdk9
+- openjdk8


### PR DESCRIPTION
https://docs.travis-ci.com/user/languages/java/#testing-against-multiple-jdks

Later java versions are supported in Liquibase so we should also compile against them