### PR TITLE
rule discovery poc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,6 @@
             <version>${commons-beanutils.version}</version>
         </dependency>
         <dependency>
-            <artifactId>spring-context</artifactId>
-            <groupId>org.springframework</groupId>
-            <version>${spring.version}</version>
-        </dependency>
-        <dependency>
             <artifactId>spring-expression</artifactId>
             <groupId>org.springframework</groupId>
             <version>${spring.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
             <version>${commons-beanutils.version}</version>
         </dependency>
         <dependency>
+            <artifactId>spring-context</artifactId>
+            <groupId>org.springframework</groupId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
             <artifactId>spring-expression</artifactId>
             <groupId>org.springframework</groupId>
             <version>${spring.version}</version>

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinter.java
@@ -83,6 +83,7 @@ public class ChangeLogLinter {
 
             for (Change change : changes) {
                 ruleRunner.forChange(change)
+                        .checkChange()
                         .run(RuleType.ILLEGAL_CHANGE_TYPES, change)
                         .run(RuleType.VALID_CONTEXT, contexts)
                         .run(RuleType.SEPARATE_DDL_CONTEXT, contexts);

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/Config.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/Config.java
@@ -46,7 +46,11 @@ public class Config {
     }
 
     public RuleRunner getRuleRunner() {
-        return new RuleRunner(this.rules);
+        return new RuleRunner(this);
+    }
+
+    public boolean isRuleEnabled(String name) {
+        return rules.containsKey(name) && rules.get(name).isEnabled();
     }
 
     static class RuleConfigDeserializer extends JsonDeserializer<Object> {

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/AbstractChangeRule.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/AbstractChangeRule.java
@@ -1,0 +1,68 @@
+package com.whiteclarkegroup.liquibaselinter.config.rules;
+
+import com.whiteclarkegroup.liquibaselinter.config.rules.checker.PatternChecker;
+import liquibase.change.Change;
+import liquibase.change.core.AddPrimaryKeyChange;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public abstract class AbstractChangeRule<T extends Change> implements ChangeRule<T> {
+    private final String name;
+    private final String message;
+    protected RuleConfig ruleConfig;
+    private PatternChecker patternChecker;
+
+    protected AbstractChangeRule(String name, String message) {
+        this.name = name;
+        this.message = message;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public abstract Class<T> getChangeType();
+
+    @Override
+    public ChangeRule configure(RuleConfig ruleConfig) {
+        this.ruleConfig = ruleConfig;
+        if (ruleConfig.hasPattern()) {
+            this.patternChecker = new PatternChecker(ruleConfig);
+        }
+        return this;
+    }
+
+    @Override
+    public RuleConfig getConfig() {
+        return ruleConfig;
+    }
+
+    @Override
+    public abstract boolean invalid(T change);
+
+    protected boolean checkNotBlank(String value) {
+        return value == null || value.equals("");
+    }
+
+    protected boolean checkPattern(String value, Change change) {
+        return patternChecker.check(value, change);
+    }
+
+    @Override
+    public String getMessage(T change) {
+        return getMesageTemplate();
+    }
+
+    private String getMesageTemplate() {
+        return Optional.ofNullable(ruleConfig.getErrorMessage()).orElse(message);
+    }
+
+    protected String formatMessage(Object... stuff) {
+        return String.format(getMesageTemplate(), Arrays.stream(stuff)
+            .map(thing -> Optional.ofNullable(thing).orElse(""))
+            .toArray());
+    }
+}

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/AbstractChangeRule.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/AbstractChangeRule.java
@@ -2,7 +2,6 @@ package com.whiteclarkegroup.liquibaselinter.config.rules;
 
 import com.whiteclarkegroup.liquibaselinter.config.rules.checker.PatternChecker;
 import liquibase.change.Change;
-import liquibase.change.core.AddPrimaryKeyChange;
 
 import java.util.Arrays;
 import java.util.Optional;

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/ChangeRule.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/ChangeRule.java
@@ -1,0 +1,17 @@
+package com.whiteclarkegroup.liquibaselinter.config.rules;
+
+import liquibase.change.Change;
+
+public interface ChangeRule<T extends Change> {
+    String getName();
+    Class<T> getChangeType();
+
+    ChangeRule configure(RuleConfig ruleConfig);
+    RuleConfig getConfig();
+
+    default boolean supports(T change) {
+        return true;
+    }
+    boolean invalid(T change);
+    String getMessage(T change);
+}

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleConfig.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleConfig.java
@@ -54,7 +54,7 @@ public class RuleConfig {
         return enabled;
     }
 
-    String getErrorMessage() {
+    public String getErrorMessage() {
         return errorMessage;
     }
 
@@ -97,6 +97,10 @@ public class RuleConfig {
             pattern = Pattern.compile(patternString);
         }
         return Optional.ofNullable(pattern);
+    }
+
+    public boolean hasPattern() {
+        return patternString != null && !patternString.equals("");
     }
 
     public static class RuleConfigBuilder {

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
@@ -1,6 +1,7 @@
 package com.whiteclarkegroup.liquibaselinter.config.rules;
 
 import com.whiteclarkegroup.liquibaselinter.ChangeLogParseExceptionHelper;
+import com.whiteclarkegroup.liquibaselinter.config.Config;
 import liquibase.change.Change;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.exception.ChangeLogParseException;
@@ -8,25 +9,27 @@ import liquibase.exception.ChangeLogParseException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.*;
 
 public class RuleRunner {
+    private final Config config;
 
-    private final Map<String, RuleConfig> ruleConfigs;
+    public RuleRunner(Config config) {
+        this.config = config;
+    }
 
-    public RuleRunner(Map<String, RuleConfig> ruleConfigs) {
-        this.ruleConfigs = ruleConfigs;
     }
 
     public RunningContext forChange(Change change) {
-        return new RunningContext(this.ruleConfigs, change, null);
+        return new RunningContext(config.getRules(), change, null);
     }
 
     public RunningContext forDatabaseChangeLog(DatabaseChangeLog databaseChangeLog) {
-        return new RunningContext(ruleConfigs, null, databaseChangeLog);
+        return new RunningContext(config.getRules(), null, databaseChangeLog);
     }
 
     public RunningContext forGeneric() {
-        return new RunningContext(ruleConfigs, null, null);
+        return new RunningContext(config.getRules(), null, null);
     }
 
     public static class RunningContext {

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleType.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleType.java
@@ -22,7 +22,6 @@ public enum RuleType {
     MODIFY_DATA_ENFORCE_WHERE("modify-data-enforce-where", ModifyDataEnforceWhere::new, "Modify data on table '%s' must have a where condition"),
     CREATE_INDEX_NAME("create-index-name", MandatoryPatternRule::new, "Index name does not follow pattern"),
     UNIQUE_CONSTRAINT_NAME("unique-constraint-name", MandatoryPatternRule::new, "Unique constraint name does not follow pattern"),
-    PRIMARY_KEY_NAME("primary-key-name", MandatoryPatternRule::new, "Primary key name is missing or does not follow pattern"),
     FOREIGN_KEY_NAME("foreign-key-name", MandatoryPatternRule::new, "Foreign key name is missing or does not follow pattern"),
     FILE_NAME_NO_SPACES("file-name-no-spaces", FileNameNoSpaces::new, "Changelog filenames should not contain spaces"),
     NO_PRECONDITIONS("no-preconditions", NullRule::new, "Preconditions are not allowed in this project"),

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/checker/PatternChecker.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/checker/PatternChecker.java
@@ -1,7 +1,6 @@
 package com.whiteclarkegroup.liquibaselinter.config.rules.checker;
 
 import com.whiteclarkegroup.liquibaselinter.config.rules.RuleConfig;
-import liquibase.change.Change;
 
 import java.util.regex.Pattern;
 

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/checker/PatternChecker.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/checker/PatternChecker.java
@@ -1,0 +1,40 @@
+package com.whiteclarkegroup.liquibaselinter.config.rules.checker;
+
+import com.whiteclarkegroup.liquibaselinter.config.rules.RuleConfig;
+import liquibase.change.Change;
+
+import java.util.regex.Pattern;
+
+public class PatternChecker {
+    private static final String DYNAMIC_VALUE = "{{value}}";
+
+    private final RuleConfig ruleConfig;
+
+    public PatternChecker(RuleConfig ruleConfig) {
+        this.ruleConfig = ruleConfig;
+    }
+
+    private Pattern getDynamicPattern(String value) {
+        return Pattern.compile(ruleConfig.getPatternString().replace(DYNAMIC_VALUE, value));
+    }
+
+    private String getDynamicValue(Object subject) {
+        return ruleConfig.getDynamicValueExpression()
+            .map(expression -> expression.getValue(subject, String.class))
+            .orElse(null);
+    }
+
+    public boolean check(String value, Object subject) {
+        if (value == null || value.equals("")) {
+            return false;
+        }
+        if (ruleConfig.getPatternString() != null) {
+            if (ruleConfig.getPatternString().contains(DYNAMIC_VALUE)) {
+                return !getDynamicPattern(getDynamicValue(subject)).matcher(value).matches();
+            } else {
+                return !ruleConfig.getPattern().map(pattern -> pattern.matcher(value).matches()).orElse(true);
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/core/PrimaryKeyNameRuleImpl.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/core/PrimaryKeyNameRuleImpl.java
@@ -1,0 +1,29 @@
+package com.whiteclarkegroup.liquibaselinter.config.rules.core;
+
+import com.whiteclarkegroup.liquibaselinter.config.rules.AbstractChangeRule;
+import liquibase.change.core.AddPrimaryKeyChange;
+
+public class PrimaryKeyNameRuleImpl extends AbstractChangeRule<AddPrimaryKeyChange> {
+    private static final String NAME = "primary-key-name";
+    private static final String MESSAGE = "Primary key name is missing or does not follow pattern";
+
+    public PrimaryKeyNameRuleImpl() {
+        super(NAME, MESSAGE);
+    }
+
+    @Override
+    public Class<AddPrimaryKeyChange> getChangeType() {
+        return AddPrimaryKeyChange.class;
+    }
+
+    @Override
+    public boolean invalid(AddPrimaryKeyChange change) {
+        final String constraintName = change.getConstraintName();
+        return checkNotBlank(constraintName) || checkPattern(constraintName, change);
+    }
+
+    @Override
+    public String getMessage(AddPrimaryKeyChange change) {
+        return formatMessage(change.getConstraintName(), ruleConfig.getPatternString());
+    }
+}

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/generic/PatternRule.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/generic/PatternRule.java
@@ -7,7 +7,6 @@ import com.whiteclarkegroup.liquibaselinter.config.rules.checker.PatternChecker;
 import liquibase.change.Change;
 
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 public class PatternRule extends Rule implements WithFormattedErrorMessage {
     private final PatternChecker patternChecker;

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/generic/PatternRule.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/generic/PatternRule.java
@@ -3,43 +3,23 @@ package com.whiteclarkegroup.liquibaselinter.config.rules.generic;
 import com.whiteclarkegroup.liquibaselinter.config.rules.Rule;
 import com.whiteclarkegroup.liquibaselinter.config.rules.RuleConfig;
 import com.whiteclarkegroup.liquibaselinter.config.rules.WithFormattedErrorMessage;
+import com.whiteclarkegroup.liquibaselinter.config.rules.checker.PatternChecker;
 import liquibase.change.Change;
 
 import java.util.Optional;
 import java.util.regex.Pattern;
 
 public class PatternRule extends Rule implements WithFormattedErrorMessage {
-
-    private static final String DYNAMIC_VALUE = "{{value}}";
+    private final PatternChecker patternChecker;
 
     public PatternRule(RuleConfig ruleConfig) {
         super(ruleConfig);
-    }
-
-    private Pattern getDynamicPattern(String value) {
-        return Pattern.compile(getRuleConfig().getPatternString().replace(DYNAMIC_VALUE, value));
-    }
-
-    private String getDynamicValue(Change change) {
-        return getRuleConfig().getDynamicValueExpression()
-                .map(expression -> expression.getValue(change, String.class))
-                .orElse(null);
+        this.patternChecker = new PatternChecker(ruleConfig);
     }
 
     @Override
     public boolean invalid(Object object, Change change) {
-        final String value = (String) object;
-        if (value == null) {
-            return false;
-        }
-        if (getRuleConfig().getPatternString() != null) {
-            if (getRuleConfig().getPatternString().contains(DYNAMIC_VALUE)) {
-                return !getDynamicPattern(getDynamicValue(change)).matcher(value).matches();
-            } else {
-                return !getRuleConfig().getPattern().map(pattern -> pattern.matcher(value).matches()).orElse(true);
-            }
-        }
-        return false;
+        return patternChecker.check((String) object, change);
     }
 
     @Override

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/linters/AddPrimaryKeyChangeLinter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/linters/AddPrimaryKeyChangeLinter.java
@@ -2,7 +2,6 @@ package com.whiteclarkegroup.liquibaselinter.linters;
 
 import com.whiteclarkegroup.liquibaselinter.Linter;
 import com.whiteclarkegroup.liquibaselinter.config.rules.RuleRunner;
-import com.whiteclarkegroup.liquibaselinter.config.rules.RuleType;
 import liquibase.change.core.AddPrimaryKeyChange;
 import liquibase.exception.ChangeLogParseException;
 
@@ -13,8 +12,6 @@ public class AddPrimaryKeyChangeLinter implements Linter<AddPrimaryKeyChange> {
     @Override
     public void lint(AddPrimaryKeyChange change, RuleRunner ruleRunner) throws ChangeLogParseException {
         getObjectNameLinter().lintObjectNameLength(change.getConstraintName(), change, ruleRunner);
-        ruleRunner.forChange(change)
-                .run(RuleType.PRIMARY_KEY_NAME, change.getConstraintName());
     }
 
     ObjectNameLinter getObjectNameLinter() {

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
@@ -2,11 +2,13 @@ package com.whiteclarkegroup.liquibaselinter.config.rules;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import com.whiteclarkegroup.liquibaselinter.config.Config;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -71,6 +73,20 @@ class ConfigTest {
         assertEquals(1, config.getRules().size());
         RuleConfig ruleConfig = config.getRules().get("file-name-no-spaces");
         assertFalse(ruleConfig.isEnabled());
+    }
+
+    @DisplayName("Should indicate whether rule enabled from config map")
+    @Test
+    void shouldIndicateWhetherRuleEnabledFromConfigMap() {
+        Map<String, RuleConfig> map = ImmutableMap.of(
+            "present-but-off", RuleConfig.disabled(),
+            "present-and-on", RuleConfig.enabled()
+        );
+        Config config = new Config(null, map);
+
+        assertFalse(config.isRuleEnabled("not-even-present"));
+        assertFalse(config.isRuleEnabled("present-but-off"));
+        assertTrue(config.isRuleEnabled("present-and-on"));
     }
 
 }

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
@@ -1,6 +1,7 @@
 package com.whiteclarkegroup.liquibaselinter.config.rules;
 
 import com.google.common.collect.ImmutableMap;
+import com.whiteclarkegroup.liquibaselinter.config.Config;
 import liquibase.change.Change;
 import liquibase.exception.ChangeLogParseException;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +28,7 @@ class RuleRunnerTest {
 
     private RuleRunner getRuleRunner() {
         final ImmutableMap<String, RuleConfig> ruleConfigMap = ImmutableMap.of(RuleType.TABLE_NAME.getKey(), RuleConfig.builder().withEnabled(true).withPattern("^(?!TBL)[A-Z_]+(?<!_)$").build());
-        return new RuleRunner(ruleConfigMap);
+        return new RuleRunner(new Config(null, ruleConfigMap));
     }
 
     private Change mockChange(String changeComment) {

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/linters/ObjectNameLinterTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/linters/ObjectNameLinterTest.java
@@ -13,9 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith({AddColumnChangeParameterResolver.class, RuleRunnerParameterResolver.class})
 class ObjectNameLinterTest {

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/resolvers/RuleRunnerParameterResolver.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/resolvers/RuleRunnerParameterResolver.java
@@ -17,7 +17,7 @@ public class RuleRunnerParameterResolver implements ParameterResolver {
 
     public RuleRunnerParameterResolver() {
         try (InputStream inputStream = getClass().getResourceAsStream("/lqllint.test.json")) {
-            this.ruleRunner = new RuleRunner(Config.fromInputStream(inputStream).getRules());
+            this.ruleRunner = new RuleRunner(Config.fromInputStream(inputStream));
         } catch (IOException e) {
             throw new UnexpectedLiquibaseException("Failed to load test lq lint default config file", e);
         }


### PR DESCRIPTION
First step towards #27.

Add code for discoverable `ChangeRule`s, including abstract base class, and reimplement one rule - `primary-key-name` - with it.

This is an early look, since I still need to go back and build out unit tests, but the existing integration tests for the reimplemented rule prove it works.