### PR TITLE
Aggregate errors and support console report

### DIFF
--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinter.java
@@ -75,7 +75,7 @@ public class ChangeLogLinter {
             Collection<String> contexts = changeSet.getContexts() != null ? changeSet.getContexts().getContexts() : Collections.emptySet();
             List<Change> changes = changeSet.getChanges();
 
-            ruleRunner.forDatabaseChangeLog(databaseChangeLog)
+            ruleRunner.forChangeSet(changeSet)
                     .run(RuleType.NO_PRECONDITIONS, changeSet.getPreconditions())
                     .run(RuleType.HAS_CONTEXT, contexts)
                     .run(RuleType.HAS_COMMENT, changeSet.getComments())

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/ChangeLogParseExceptionHelper.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/ChangeLogParseExceptionHelper.java
@@ -1,6 +1,5 @@
 package com.whiteclarkegroup.liquibaselinter;
 
-import liquibase.change.Change;
 import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
 import liquibase.exception.ChangeLogParseException;
@@ -11,9 +10,10 @@ public class ChangeLogParseExceptionHelper {
 
     }
 
-    public static ChangeLogParseException build(DatabaseChangeLog databaseChangeLog, Change change, String customMessage) {
-        if (change != null) {
-            return build(change.getChangeSet(), customMessage);
+    public static ChangeLogParseException build(DatabaseChangeLog databaseChangeLog, ChangeSet changeSet, String customMessage) {
+        if (changeSet != null) {
+            final String message = "File name: " + changeSet.getFilePath() + " -- Change Set ID: " + changeSet.getId() + " -- Author: " + changeSet.getAuthor() + " -- Message: " + customMessage;
+            return new ChangeLogParseException(message);
         } else if (databaseChangeLog != null) {
             return build(databaseChangeLog, customMessage);
         }
@@ -22,11 +22,6 @@ public class ChangeLogParseExceptionHelper {
 
     private static ChangeLogParseException build(DatabaseChangeLog databaseChangeLog, String customMessage) {
         final String message = "File name: " + databaseChangeLog.getFilePath() + " -- Message: " + customMessage;
-        return new ChangeLogParseException(message);
-    }
-
-    private static ChangeLogParseException build(ChangeSet changeSet, String customMessage) {
-        final String message = "File name: " + changeSet.getFilePath() + " -- Change Set ID: " + changeSet.getId() + " -- Author: " + changeSet.getAuthor() + " -- Message: " + customMessage;
         return new ChangeLogParseException(message);
     }
 

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/Config.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/Config.java
@@ -30,7 +30,7 @@ public class Config {
     @JsonCreator
     public Config(@JsonProperty("ignore-context-pattern") String ignoreContextPatternString,
                   @JsonProperty("rules") Map<String, RuleConfig> rules,
-                  @JsonProperty("failFast") boolean failFast) {
+                  @JsonProperty("fail-fast") boolean failFast) {
         this.ignoreContextPattern = ignoreContextPatternString != null ? Pattern.compile(ignoreContextPatternString) : null;
         this.rules = rules;
         this.failFast = failFast;

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/Config.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/Config.java
@@ -25,12 +25,15 @@ public class Config {
     private final Pattern ignoreContextPattern;
     @JsonDeserialize(using = RuleConfigDeserializer.class)
     private final Map<String, RuleConfig> rules;
+    private final boolean failFast;
 
     @JsonCreator
     public Config(@JsonProperty("ignore-context-pattern") String ignoreContextPatternString,
-                  @JsonProperty("rules") Map<String, RuleConfig> rules) {
+                  @JsonProperty("rules") Map<String, RuleConfig> rules,
+                  @JsonProperty("failFast") boolean failFast) {
         this.ignoreContextPattern = ignoreContextPatternString != null ? Pattern.compile(ignoreContextPatternString) : null;
         this.rules = rules;
+        this.failFast = failFast;
     }
 
     public static Config fromInputStream(final InputStream inputStream) throws IOException {
@@ -47,6 +50,10 @@ public class Config {
 
     public RuleRunner getRuleRunner() {
         return new RuleRunner(this.rules);
+    }
+
+    public boolean isFailFast() {
+        return failFast;
     }
 
     static class RuleConfigDeserializer extends JsonDeserializer<Object> {

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
@@ -48,7 +48,7 @@ public class RuleRunner {
     }
 
     public RunningContext forChange(Change change) {
-        return new RunningContext(config, changeRules, change, null, report.getReportItems(), change.getChangeSet());
+        return new RunningContext(config, changeRules, change, change.getChangeSet().getChangeLog(), report.getReportItems(), change.getChangeSet());
     }
 
     public RunningContext forDatabaseChangeLog(DatabaseChangeLog databaseChangeLog) {
@@ -56,7 +56,7 @@ public class RuleRunner {
     }
 
     public RunningContext forChangeSet(ChangeSet changeSet) {
-        return new RunningContext(config, null, null, null, report.getReportItems(), changeSet);
+        return new RunningContext(config, null, null, changeSet.getChangeLog(), report.getReportItems(), changeSet);
     }
 
     public RunningContext forGeneric() {
@@ -67,17 +67,15 @@ public class RuleRunner {
     public static class RunningContext {
 
         private static final String LQL_IGNORE_TOKEN = "lql-ignore:";
-        private final Map<String, RuleConfig> ruleConfigs;
+        private final Config config;
         private final List<ChangeRule> changeRules;
         private final Change change;
         private final DatabaseChangeLog databaseChangeLog;
-        private final Config config;
         private final Collection<ReportItem> reportItems;
         private final ChangeSet changeSet;
 
         private RunningContext(Config config, List<ChangeRule> changeRules, Change change, DatabaseChangeLog databaseChangeLog, Collection<ReportItem> reportItems, ChangeSet changeSet) {
             this.config = config;
-            this.ruleConfigs = config.getRules();
             this.changeRules = changeRules;
             this.change = change;
             this.databaseChangeLog = databaseChangeLog;
@@ -103,7 +101,7 @@ public class RuleRunner {
 
         @SuppressWarnings("unchecked")
         public RunningContext run(RuleType ruleType, Object object) throws ChangeLogParseException {
-            final Optional<Rule> optionalRule = ruleType.create(ruleConfigs);
+            final Optional<Rule> optionalRule = ruleType.create(config.getRules());
             if (optionalRule.isPresent()) {
                 Rule rule = optionalRule.get();
                 final String errorMessage = getErrorMessage(ruleType, object, rule);

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
@@ -2,6 +2,7 @@ package com.whiteclarkegroup.liquibaselinter.config.rules;
 
 import com.whiteclarkegroup.liquibaselinter.ChangeLogParseExceptionHelper;
 import com.whiteclarkegroup.liquibaselinter.config.Config;
+import com.whiteclarkegroup.liquibaselinter.report.Report;
 import com.whiteclarkegroup.liquibaselinter.report.ReportItem;
 import liquibase.change.Change;
 import liquibase.changelog.DatabaseChangeLog;
@@ -18,16 +19,15 @@ public class RuleRunner {
 
     private final Config config;
     private final List<ChangeRule> changeRules;
-    private final Collection<ReportItem> reportItems;
+    private final Report report = new Report();
 
     public RuleRunner(Config config) {
         this.config = config;
         this.changeRules = discoverChangeRules();
-        this.reportItems = new HashSet<>();
     }
 
-    public Collection<ReportItem> getReportItems() {
-        return reportItems;
+    public Report getReport() {
+        return report;
     }
 
     private List<ChangeRule> discoverChangeRules() {
@@ -47,15 +47,15 @@ public class RuleRunner {
     }
 
     public RunningContext forChange(Change change) {
-        return new RunningContext(config, changeRules, change, null, reportItems);
+        return new RunningContext(config, changeRules, change, null, report.getReportItems());
     }
 
     public RunningContext forDatabaseChangeLog(DatabaseChangeLog databaseChangeLog) {
-        return new RunningContext(config, null, null, databaseChangeLog, reportItems);
+        return new RunningContext(config, null, null, databaseChangeLog, report.getReportItems());
     }
 
     public RunningContext forGeneric() {
-        return new RunningContext(config, null, null, null, reportItems);
+        return new RunningContext(config, null, null, null, report.getReportItems());
     }
 
     public static class RunningContext {

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
@@ -1,0 +1,14 @@
+package com.whiteclarkegroup.liquibaselinter.report;
+
+public class ConsoleReporter implements Reporter {
+
+    private static final String RESET = "\033[0m";
+    private static final String RED = "\033[0;31m";
+    private static final String YELLOW = "\033[0;33m";
+
+    @Override
+    public void report() {
+
+    }
+
+}

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
@@ -1,13 +1,15 @@
 package com.whiteclarkegroup.liquibaselinter.report;
 
-public class ConsoleReporter implements Reporter {
+import java.util.Collection;
+
+public class ConsoleReporter extends Reporter {
 
     private static final String RESET = "\033[0m";
     private static final String RED = "\033[0;31m";
     private static final String YELLOW = "\033[0;33m";
 
     @Override
-    public void report() {
+    public void report(Collection<ReportItem> reportItems) {
 
     }
 

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
@@ -1,16 +1,50 @@
 package com.whiteclarkegroup.liquibaselinter.report;
 
-import java.util.Collection;
-
 public class ConsoleReporter implements Reporter {
 
-    private static final String RESET = "\033[0m";
-    private static final String RED = "\033[0;31m";
-    private static final String YELLOW = "\033[0;33m";
+    static final String RESET = "\033[0m";
+    static final String RED = "\033[0;31m";
+    static final String YELLOW = "\033[0;33m";
+    private static final String NEW_LINE = "\n";
 
     @Override
-    public void report(Collection<ReportItem> reportItems) {
+    public void processReport(Report report) {
+        StringBuilder output = new StringBuilder();
+        report.getByFileName().forEach((key, value) -> {
+            output.append(NEW_LINE).append(key).append(NEW_LINE);
+            value.forEach(item -> {
+                printTypeChangeSetLine(output, item);
+                printRuleLine(output, item);
+            });
+        });
+        printToConsole(output);
+    }
 
+    private void printToConsole(StringBuilder output) {
+        System.out.println(output.toString());
+    }
+
+    private void printTypeChangeSetLine(StringBuilder output, ReportItem item) {
+        output.append(getType(item));
+        if (item.getChangeSetId() != null) {
+            output.append(" changeSet '").append(item.getChangeSetId()).append("'");
+        }
+        output.append(NEW_LINE);
+    }
+
+    private void printRuleLine(StringBuilder output, ReportItem item) {
+        output.append("\t'").append(item.getRule()).append("': ").append(item.getMessage()).append(NEW_LINE);
+    }
+
+    private String getType(ReportItem item) {
+        switch (item.getType()) {
+            case ERROR:
+                return RESET + RED + item.getType().name() + RESET;
+            case IGNORED:
+                return RESET + YELLOW + item.getType().name() + RESET;
+            default:
+                return item.getType().name();
+        }
     }
 
 }

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
@@ -69,9 +69,9 @@ public class ConsoleReporter implements Reporter {
     private String getType(ReportItem.ReportItemType type) {
         switch (type) {
             case ERROR:
-                return RESET + RED + type + RESET;
+                return coloured(RED, type.name());
             case IGNORED:
-                return RESET + YELLOW + type + RESET;
+                return coloured(YELLOW, type.name());
             default:
                 return type.name();
         }

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
@@ -2,7 +2,7 @@ package com.whiteclarkegroup.liquibaselinter.report;
 
 import java.util.Collection;
 
-public class ConsoleReporter extends Reporter {
+public class ConsoleReporter implements Reporter {
 
     private static final String RESET = "\033[0m";
     private static final String RED = "\033[0;31m";

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporter.java
@@ -26,7 +26,7 @@ public class ConsoleReporter implements Reporter {
 
     private void printTypeChangeSetLine(StringBuilder output, ReportItem item) {
         output.append(getType(item));
-        if (item.getChangeSetId() != null) {
+        if (item.getChangeSetId() != null && !item.getChangeSetId().isEmpty()) {
             output.append(" changeSet '").append(item.getChangeSetId()).append("'");
         }
         output.append(NEW_LINE);

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Report.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Report.java
@@ -1,0 +1,29 @@
+package com.whiteclarkegroup.liquibaselinter.report;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class Report {
+
+    private final Collection<ReportItem> reportItems = new ArrayList<>();
+
+    public Collection<ReportItem> getReportItems() {
+        return reportItems;
+    }
+
+    public Map<String, List<ReportItem>> getByFileName() {
+        return reportItems.stream().collect(Collectors.groupingBy(ReportItem::getFilePath));
+    }
+
+    public long countErrors() {
+        return reportItems.stream().filter(item -> item.getType() == ReportItem.ReportItemType.ERROR).count();
+    }
+
+    public boolean hasItems() {
+        return !reportItems.isEmpty();
+    }
+
+}

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ReportItem.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ReportItem.java
@@ -37,7 +37,7 @@ public class ReportItem {
         } else if (databaseChangeLog != null) {
             return databaseChangeLog.getFilePath();
         } else {
-            return "Generic rule";
+            return "Other";
         }
     }
 

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ReportItem.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ReportItem.java
@@ -1,6 +1,6 @@
 package com.whiteclarkegroup.liquibaselinter.report;
 
-import liquibase.change.Change;
+import liquibase.changelog.ChangeSet;
 import liquibase.changelog.DatabaseChangeLog;
 
 public class ReportItem {
@@ -16,24 +16,24 @@ public class ReportItem {
     private final ReportItemType type;
     private final String message;
 
-    public static ReportItem error(DatabaseChangeLog databaseChangeLog, Change change, String rule, String message) {
-        return new ReportItem(getFilePath(databaseChangeLog, change), getChangeSetId(change), rule, ReportItemType.ERROR, message);
+    public static ReportItem error(DatabaseChangeLog databaseChangeLog, ChangeSet changeSet, String rule, String message) {
+        return new ReportItem(getFilePath(databaseChangeLog, changeSet), getChangeSetId(changeSet), rule, ReportItemType.ERROR, message);
     }
 
-    public static ReportItem ignored(DatabaseChangeLog databaseChangeLog, Change change, String rule, String message) {
-        return new ReportItem(getFilePath(databaseChangeLog, change), getChangeSetId(change), rule, ReportItemType.IGNORED, message);
+    public static ReportItem ignored(DatabaseChangeLog databaseChangeLog, ChangeSet changeSet, String rule, String message) {
+        return new ReportItem(getFilePath(databaseChangeLog, changeSet), getChangeSetId(changeSet), rule, ReportItemType.IGNORED, message);
     }
 
-    private static String getChangeSetId(Change change) {
-        if (change != null) {
-            return change.getChangeSet().getId();
+    private static String getChangeSetId(ChangeSet changeSet) {
+        if (changeSet != null) {
+            return changeSet.getId();
         }
-        return null;
+        return "";
     }
 
-    private static String getFilePath(DatabaseChangeLog databaseChangeLog, Change change) {
-        if (change != null) {
-            return change.getChangeSet().getFilePath();
+    private static String getFilePath(DatabaseChangeLog databaseChangeLog, ChangeSet changeSet) {
+        if (changeSet != null) {
+            return changeSet.getFilePath();
         } else if (databaseChangeLog != null) {
             return databaseChangeLog.getFilePath();
         } else {

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ReportItem.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ReportItem.java
@@ -5,7 +5,7 @@ import liquibase.changelog.DatabaseChangeLog;
 
 public class ReportItem {
 
-    private enum ReportItemType {
+    public enum ReportItemType {
         ERROR,
         IGNORED
     }
@@ -25,21 +25,20 @@ public class ReportItem {
     }
 
     private static String getChangeSetId(Change change) {
-        String changeSetId = "";
         if (change != null) {
-            changeSetId = change.getChangeSet().getId();
+            return change.getChangeSet().getId();
         }
-        return changeSetId;
+        return null;
     }
 
     private static String getFilePath(DatabaseChangeLog databaseChangeLog, Change change) {
-        String filePath = "";
         if (change != null) {
-            filePath = change.getChangeSet().getFilePath();
+            return change.getChangeSet().getFilePath();
         } else if (databaseChangeLog != null) {
-            filePath = databaseChangeLog.getFilePath();
+            return databaseChangeLog.getFilePath();
+        } else {
+            return "Generic rule";
         }
-        return filePath;
     }
 
     private ReportItem(String filePath, String changeSetId, String rule, ReportItemType type, String message) {

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ReportItem.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/ReportItem.java
@@ -1,0 +1,72 @@
+package com.whiteclarkegroup.liquibaselinter.report;
+
+import liquibase.change.Change;
+import liquibase.changelog.DatabaseChangeLog;
+
+public class ReportItem {
+
+    private enum ReportItemType {
+        ERROR,
+        IGNORED
+    }
+
+    private final String filePath;
+    private final String changeSetId;
+    private final String rule;
+    private final ReportItemType type;
+    private final String message;
+
+    public static ReportItem error(DatabaseChangeLog databaseChangeLog, Change change, String rule, String message) {
+        return new ReportItem(getFilePath(databaseChangeLog, change), getChangeSetId(change), rule, ReportItemType.ERROR, message);
+    }
+
+    public static ReportItem ignored(DatabaseChangeLog databaseChangeLog, Change change, String rule, String message) {
+        return new ReportItem(getFilePath(databaseChangeLog, change), getChangeSetId(change), rule, ReportItemType.IGNORED, message);
+    }
+
+    private static String getChangeSetId(Change change) {
+        String changeSetId = "";
+        if (change != null) {
+            changeSetId = change.getChangeSet().getId();
+        }
+        return changeSetId;
+    }
+
+    private static String getFilePath(DatabaseChangeLog databaseChangeLog, Change change) {
+        String filePath = "";
+        if (change != null) {
+            filePath = change.getChangeSet().getFilePath();
+        } else if (databaseChangeLog != null) {
+            filePath = databaseChangeLog.getFilePath();
+        }
+        return filePath;
+    }
+
+    private ReportItem(String filePath, String changeSetId, String rule, ReportItemType type, String message) {
+        this.filePath = filePath;
+        this.changeSetId = changeSetId;
+        this.rule = rule;
+        this.type = type;
+        this.message = message;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public String getChangeSetId() {
+        return changeSetId;
+    }
+
+    public String getRule() {
+        return rule;
+    }
+
+    public ReportItemType getType() {
+        return type;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Reporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Reporter.java
@@ -1,5 +1,16 @@
 package com.whiteclarkegroup.liquibaselinter.report;
 
-public interface Reporter {
-    void report();
+import java.util.ArrayList;
+import java.util.Collection;
+
+public abstract class Reporter {
+
+    public static final Collection<Reporter> REPORTERS = new ArrayList<>();
+
+    Reporter() {
+        REPORTERS.add(this);
+    }
+
+    abstract void report(Collection<ReportItem> reportItems);
+
 }

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Reporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Reporter.java
@@ -1,16 +1,7 @@
 package com.whiteclarkegroup.liquibaselinter.report;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
-public abstract class Reporter {
-
-    public static final Collection<Reporter> REPORTERS = new ArrayList<>();
-
-    Reporter() {
-        REPORTERS.add(this);
-    }
-
-    abstract void report(Collection<ReportItem> reportItems);
-
+public interface Reporter {
+    void report(Collection<ReportItem> reportItems);
 }

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Reporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Reporter.java
@@ -1,0 +1,5 @@
+package com.whiteclarkegroup.liquibaselinter.report;
+
+public interface Reporter {
+    void report();
+}

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Reporter.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Reporter.java
@@ -1,7 +1,5 @@
 package com.whiteclarkegroup.liquibaselinter.report;
 
-import java.util.Collection;
-
 public interface Reporter {
-    void report(Collection<ReportItem> reportItems);
+    void processReport(Report report);
 }

--- a/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
+++ b/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
@@ -1,5 +1,6 @@
 package liquibase.parser.ext;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.whiteclarkegroup.liquibaselinter.ChangeLogLinter;
 import com.whiteclarkegroup.liquibaselinter.config.Config;
@@ -29,6 +30,8 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
     private final ChangeLogLinter changeLogLinter = new ChangeLogLinter();
     protected Config config;
 
+    private static final Collection<Reporter> REPORTERS = ImmutableList.of(new ConsoleReporter());
+
     @Override
     public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
         loadConfig(resourceAccessor);
@@ -57,7 +60,7 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
         changeLogLinter.lintChangeLog(changeLog, config, ruleRunner);
 
         if (changeLog.getRootChangeLog() == changeLog && !config.isFailFast()) {
-            Reporter.REPORTERS.forEach(Reporter::report);
+            REPORTERS.forEach(reporter -> reporter.report(ruleRunner.getReportItems()));
         }
 
         return changeLog;

--- a/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
+++ b/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
@@ -29,8 +29,6 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
     private final ChangeLogLinter changeLogLinter = new ChangeLogLinter();
     protected Config config;
 
-    private static final Collection<Reporter> REPORTERS = Collections.singletonList(new ConsoleReporter());
-
     @Override
     public DatabaseChangeLog parse(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
         loadConfig(resourceAccessor);
@@ -59,7 +57,7 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
         changeLogLinter.lintChangeLog(changeLog, config, ruleRunner);
 
         if (changeLog.getRootChangeLog() == changeLog && !config.isFailFast()) {
-            REPORTERS.forEach(Reporter::report);
+            Reporter.REPORTERS.forEach(Reporter::report);
         }
 
         return changeLog;

--- a/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
+++ b/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
@@ -71,7 +71,7 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
 
     private void runReports(String physicalChangeLogLocation, Report report) throws ChangeLogParseException {
         //TODO move to DatabaseChangeLog::getRootChangeLog when we support liquibase 3.6 minimum
-        if (rootPhysicalChangeLogLocation.equals(physicalChangeLogLocation) && !config.isFailFast() && report.hasItems()) {
+        if (rootPhysicalChangeLogLocation.equals(physicalChangeLogLocation) && report.hasItems()) {
             REPORTERS.forEach(reporter -> reporter.processReport(report));
             throw new ChangeLogParseException(String.format("Linting failed with %d errors", report.countErrors()));
         }

--- a/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
+++ b/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
@@ -49,6 +49,11 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
         }
 
         changeLogLinter.lintChangeLog(changeLog, config, ruleRunner);
+
+        if (changeLog.getRootChangeLog() == changeLog && !config.isFailFast()) {
+            checkErrors(ruleRunner);
+        }
+
         return changeLog;
     }
 
@@ -89,4 +94,9 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
             alreadyParsed.add(physicalChangeLogLocation);
         }
     }
+
+    private void checkErrors(RuleRunner ruleRunner) {
+
+    }
+
 }

--- a/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
+++ b/src/main/java/liquibase/parser/ext/CustomXMLChangeLogSAXParser.java
@@ -73,7 +73,9 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
         //TODO move to DatabaseChangeLog::getRootChangeLog when we support liquibase 3.6 minimum
         if (rootPhysicalChangeLogLocation.equals(physicalChangeLogLocation) && report.hasItems()) {
             REPORTERS.forEach(reporter -> reporter.processReport(report));
-            throw new ChangeLogParseException(String.format("Linting failed with %d errors", report.countErrors()));
+            if (report.countErrors() > 0) {
+                throw new ChangeLogParseException(String.format("Linting failed with %d errors", report.countErrors()));
+            }
         }
     }
 

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
@@ -82,7 +82,7 @@ class ConfigTest {
             "present-but-off", RuleConfig.disabled(),
             "present-and-on", RuleConfig.enabled()
         );
-        Config config = new Config(null, map);
+        Config config = new Config(null, map, true);
 
         assertFalse(config.isRuleEnabled("not-even-present"));
         assertFalse(config.isRuleEnabled("present-but-off"));

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
@@ -28,7 +28,7 @@ class RuleRunnerTest {
 
     private RuleRunner getRuleRunner() {
         final ImmutableMap<String, RuleConfig> ruleConfigMap = ImmutableMap.of(RuleType.TABLE_NAME.getKey(), RuleConfig.builder().withEnabled(true).withPattern("^(?!TBL)[A-Z_]+(?<!_)$").build());
-        return new RuleRunner(new Config(null, ruleConfigMap));
+        return new RuleRunner(new Config(null, ruleConfigMap, true));
     }
 
     private Change mockChange(String changeComment) {

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
@@ -23,7 +23,7 @@ class RuleRunnerTest {
         ChangeLogParseException changeLogParseException =
                 assertThrows(ChangeLogParseException.class, () -> ruleRunner.forChange(mockChange(null)).run(RuleType.TABLE_NAME, "TBL_TEST"));
 
-        assertTrue(changeLogParseException.getMessage().contains("Message: Table name does not follow pattern"));
+        assertTrue(changeLogParseException.getMessage().contains("Table name does not follow pattern"));
     }
 
     private RuleRunner getRuleRunner() {

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/AggregateErrorsIntegrationTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/AggregateErrorsIntegrationTest.java
@@ -1,0 +1,23 @@
+package com.whiteclarkegroup.liquibaselinter.integration;
+
+import com.whiteclarkegroup.liquibaselinter.resolvers.LiquibaseIntegrationTestResolver;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Collections;
+import java.util.List;
+
+@ExtendWith(LiquibaseIntegrationTestResolver.class)
+class AggregateErrorsIntegrationTest extends LinterIntegrationTest {
+
+    @Override
+    List<IntegrationTestConfig> getTests() {
+        IntegrationTestConfig test1 = IntegrationTestConfig.shouldFail(
+            "Should aggregate errors",
+            "aggregate-errors.xml",
+            "aggregate-errors.json",
+            "Linting failed with 3 errors");
+
+        return Collections.singletonList(test1);
+    }
+
+}

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/LinterIntegrationTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/LinterIntegrationTest.java
@@ -5,6 +5,9 @@ import com.whiteclarkegroup.liquibaselinter.resolvers.LiquibaseIntegrationTestRe
 import liquibase.Contexts;
 import liquibase.Liquibase;
 import liquibase.exception.ChangeLogParseException;
+import liquibase.parser.ChangeLogParserFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.function.ThrowingConsumer;
@@ -34,6 +37,11 @@ abstract class LinterIntegrationTest {
             }
         };
         return DynamicTest.stream(getTests().iterator(), IntegrationTestConfig::getDisplayName, testExecutor);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        ChangeLogParserFactory.reset();
     }
 
 }

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/LinterIntegrationTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/LinterIntegrationTest.java
@@ -31,7 +31,10 @@ abstract class LinterIntegrationTest {
             final Contexts contexts = new Contexts();
             if (running.getMessage() != null) {
                 ChangeLogParseException changeLogParseException = assertThrows(ChangeLogParseException.class, () -> liquibase.update(contexts, nullWriter));
+                System.out.println(changeLogParseException.getMessage());
+                System.out.println(running.getMessage());
                 assertTrue(changeLogParseException.getMessage().contains(running.getMessage()));
+
             } else {
                 liquibase.update(contexts, nullWriter);
             }
@@ -39,8 +42,8 @@ abstract class LinterIntegrationTest {
         return DynamicTest.stream(getTests().iterator(), IntegrationTestConfig::getDisplayName, testExecutor);
     }
 
-    @AfterAll
-    static void tearDown() {
+    @AfterEach
+    void tearDown() {
         ChangeLogParserFactory.reset();
     }
 

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporterTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporterTest.java
@@ -1,0 +1,52 @@
+package com.whiteclarkegroup.liquibaselinter.report;
+
+import com.google.common.collect.ImmutableList;
+import com.whiteclarkegroup.liquibaselinter.resolvers.AddColumnChangeParameterResolver;
+import liquibase.change.core.AddColumnChange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(AddColumnChangeParameterResolver.class)
+class ConsoleReporterTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    private ConsoleReporter consoleReporter;
+
+    @BeforeEach
+    void setUp() {
+        consoleReporter = new ConsoleReporter();
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    void shouldProduceReport(AddColumnChange addColumnChange) {
+        addColumnChange.getChangeSet().setFilePath("src/main/resources/ddl/add-test-column.xml");
+        final ReportItem error = ReportItem.error(null, addColumnChange, "test-rule", "Some rather long message about the error");
+        final ReportItem ignored = ReportItem.ignored(null, addColumnChange, "another-rule", "Some other message about this rule");
+        Collection<ReportItem> reportItems = ImmutableList.of(error, ignored);
+        Report report = new Report();
+        report.getReportItems().addAll(reportItems);
+        consoleReporter.processReport(report);
+        assertEquals("\n" +
+            "src/main/resources/ddl/add-test-column.xml\n" +
+            ConsoleReporter.RESET + ConsoleReporter.RED + "ERROR" + ConsoleReporter.RESET + "\n" +
+            "\t'test-rule': Some rather long message about the error\n" +
+            ConsoleReporter.RESET + ConsoleReporter.YELLOW + "IGNORED" + ConsoleReporter.RESET + "\n" +
+            "\t'another-rule': Some other message about this rule\n\n", outContent.toString());
+    }
+}

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporterTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporterTest.java
@@ -1,33 +1,30 @@
 package com.whiteclarkegroup.liquibaselinter.report;
 
 import com.google.common.collect.ImmutableList;
-import com.whiteclarkegroup.liquibaselinter.resolvers.AddColumnChangeParameterResolver;
-import liquibase.change.core.AddColumnChange;
 import liquibase.changelog.ChangeSet;
+import liquibase.changelog.DatabaseChangeLog;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Collection;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(AddColumnChangeParameterResolver.class)
 class ConsoleReporterTest {
 
-    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private final PrintStream originalOut = System.out;
-
+    private ByteArrayOutputStream outContent;
     private ConsoleReporter consoleReporter;
 
     @BeforeEach
     void setUp() {
+        outContent = new ByteArrayOutputStream();
         consoleReporter = new ConsoleReporter();
         System.setOut(new PrintStream(outContent));
     }
@@ -35,43 +32,63 @@ class ConsoleReporterTest {
     @AfterEach
     void tearDown() {
         System.setOut(originalOut);
+        System.out.println(outContent.toString());
     }
 
     @DisplayName("Should produce report without change set id if not present")
     @Test
-    void shouldProduceReportWithoutChangeSetId(AddColumnChange addColumnChange) {
-        addColumnChange.getChangeSet().setFilePath("src/main/resources/ddl/add-test-column.xml");
-        final ReportItem error = ReportItem.error(null, addColumnChange.getChangeSet(), "test-rule", "Some rather long message about the error");
-        final ReportItem ignored = ReportItem.ignored(null, addColumnChange.getChangeSet(), "another-rule", "Some other message about this rule");
+    void shouldProduceReportWithoutChangeSet() {
+        DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
+        when(databaseChangeLog.getFilePath()).thenReturn("src/main/resources/ddl/add-test-column.xml");
+        final ReportItem error = ReportItem.error(databaseChangeLog, null, "test-rule", "Some rather long message about the error");
+        final ReportItem ignored = ReportItem.ignored(databaseChangeLog, null, "another-rule", "Some other message about this rule");
         Collection<ReportItem> reportItems = ImmutableList.of(error, ignored);
         Report report = new Report();
         report.getReportItems().addAll(reportItems);
         consoleReporter.processReport(report);
-        assertEquals("\n" +
-            "src/main/resources/ddl/add-test-column.xml\n" +
-            ConsoleReporter.RESET + ConsoleReporter.RED + "ERROR" + ConsoleReporter.RESET + "\n" +
+        assertTrue(outContent.toString().contains(  "src/main/resources/ddl/add-test-column.xml\n" +
+            ConsoleReporter.RESET + ConsoleReporter.RED + "ERROR" + ConsoleReporter.RESET +"\n" +
             "\t'test-rule': Some rather long message about the error\n" +
             ConsoleReporter.RESET + ConsoleReporter.YELLOW + "IGNORED" + ConsoleReporter.RESET + "\n" +
-            "\t'another-rule': Some other message about this rule\n\n", outContent.toString());
+            "\t'another-rule': Some other message about this rule\n"));
     }
 
-    @DisplayName("Should produce report with change set id if present")
+    @DisplayName("Should produce report with change set id if present, grouping by change set then type")
     @Test
     void shouldProduceReportWithChangeSetId() {
-        ChangeSet changeSet = mock(ChangeSet.class);
-        when(changeSet.getFilePath()).thenReturn("src/main/resources/ddl/add-test-column.xml");
-        when(changeSet.getId()).thenReturn("2018010101");
-        final ReportItem error = ReportItem.error(null, changeSet, "test-rule", "Some rather long message about the error");
-        final ReportItem ignored = ReportItem.ignored(null, changeSet, "another-rule", "Some other message about this rule");
-        Collection<ReportItem> reportItems = ImmutableList.of(error, ignored);
+        ChangeSet changeSet1 = mockChangeSet("2018010101");
+        final ReportItem error1 = ReportItem.error(null, changeSet1, "test-rule", "Some rather long message about the error");
+        final ReportItem ignored1 = ReportItem.ignored(null, changeSet1, "another-rule", "Some other message about this rule");
+
+        ChangeSet changeSet2 = mockChangeSet("2018010199");
+        final ReportItem error2 = ReportItem.error(null, changeSet2, "test-rule", "Some rather long message about the error");
+        final ReportItem error3 = ReportItem.error(null, changeSet2, "test-rule", "Some rather long message about the error 3");
+        final ReportItem ignored2 = ReportItem.ignored(null, changeSet2, "another-rule", "Some other message about this rule");
+
+        Collection<ReportItem> reportItems = ImmutableList.of(error1, ignored1, error2, ignored2, error3);
         Report report = new Report();
         report.getReportItems().addAll(reportItems);
         consoleReporter.processReport(report);
-        assertEquals("\n" +
-            "src/main/resources/ddl/add-test-column.xml\n" +
-            ConsoleReporter.RESET + ConsoleReporter.RED + "ERROR" + ConsoleReporter.RESET + " changeSet '2018010101'\n" +
+
+        assertTrue(outContent.toString().contains(  "src/main/resources/ddl/add-test-column.xml\n" +
+            "changeSet '2018010101'\n" +
+            ConsoleReporter.RESET + ConsoleReporter.RED + "ERROR" + ConsoleReporter.RESET +"\n" +
             "\t'test-rule': Some rather long message about the error\n" +
-            ConsoleReporter.RESET + ConsoleReporter.YELLOW + "IGNORED" + ConsoleReporter.RESET + " changeSet '2018010101'\n" +
-            "\t'another-rule': Some other message about this rule\n\n", outContent.toString());
+            ConsoleReporter.RESET + ConsoleReporter.YELLOW + "IGNORED" + ConsoleReporter.RESET + "\n" +
+            "\t'another-rule': Some other message about this rule\n" +
+            "changeSet '2018010199'\n" +
+            ConsoleReporter.RESET + ConsoleReporter.RED + "ERROR" + ConsoleReporter.RESET +"\n" +
+            "\t'test-rule': Some rather long message about the error\n" +
+            "\t'test-rule': Some rather long message about the error 3\n" +
+            ConsoleReporter.RESET + ConsoleReporter.YELLOW + "IGNORED" + ConsoleReporter.RESET +"\n" +
+            "\t'another-rule': Some other message about this rule\n"));
+
+    }
+
+    private ChangeSet mockChangeSet(String changeSetId) {
+        ChangeSet changeSet = mock(ChangeSet.class);
+        when(changeSet.getFilePath()).thenReturn("src/main/resources/ddl/add-test-column.xml");
+        when(changeSet.getId()).thenReturn(changeSetId);
+        return changeSet;
     }
 }

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporterTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/report/ConsoleReporterTest.java
@@ -3,8 +3,10 @@ package com.whiteclarkegroup.liquibaselinter.report;
 import com.google.common.collect.ImmutableList;
 import com.whiteclarkegroup.liquibaselinter.resolvers.AddColumnChangeParameterResolver;
 import liquibase.change.core.AddColumnChange;
+import liquibase.changelog.ChangeSet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -13,6 +15,8 @@ import java.io.PrintStream;
 import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(AddColumnChangeParameterResolver.class)
 class ConsoleReporterTest {
@@ -33,11 +37,12 @@ class ConsoleReporterTest {
         System.setOut(originalOut);
     }
 
+    @DisplayName("Should produce report without change set id if not present")
     @Test
-    void shouldProduceReport(AddColumnChange addColumnChange) {
+    void shouldProduceReportWithoutChangeSetId(AddColumnChange addColumnChange) {
         addColumnChange.getChangeSet().setFilePath("src/main/resources/ddl/add-test-column.xml");
-        final ReportItem error = ReportItem.error(null, addColumnChange, "test-rule", "Some rather long message about the error");
-        final ReportItem ignored = ReportItem.ignored(null, addColumnChange, "another-rule", "Some other message about this rule");
+        final ReportItem error = ReportItem.error(null, addColumnChange.getChangeSet(), "test-rule", "Some rather long message about the error");
+        final ReportItem ignored = ReportItem.ignored(null, addColumnChange.getChangeSet(), "another-rule", "Some other message about this rule");
         Collection<ReportItem> reportItems = ImmutableList.of(error, ignored);
         Report report = new Report();
         report.getReportItems().addAll(reportItems);
@@ -47,6 +52,26 @@ class ConsoleReporterTest {
             ConsoleReporter.RESET + ConsoleReporter.RED + "ERROR" + ConsoleReporter.RESET + "\n" +
             "\t'test-rule': Some rather long message about the error\n" +
             ConsoleReporter.RESET + ConsoleReporter.YELLOW + "IGNORED" + ConsoleReporter.RESET + "\n" +
+            "\t'another-rule': Some other message about this rule\n\n", outContent.toString());
+    }
+
+    @DisplayName("Should produce report with change set id if present")
+    @Test
+    void shouldProduceReportWithChangeSetId() {
+        ChangeSet changeSet = mock(ChangeSet.class);
+        when(changeSet.getFilePath()).thenReturn("src/main/resources/ddl/add-test-column.xml");
+        when(changeSet.getId()).thenReturn("2018010101");
+        final ReportItem error = ReportItem.error(null, changeSet, "test-rule", "Some rather long message about the error");
+        final ReportItem ignored = ReportItem.ignored(null, changeSet, "another-rule", "Some other message about this rule");
+        Collection<ReportItem> reportItems = ImmutableList.of(error, ignored);
+        Report report = new Report();
+        report.getReportItems().addAll(reportItems);
+        consoleReporter.processReport(report);
+        assertEquals("\n" +
+            "src/main/resources/ddl/add-test-column.xml\n" +
+            ConsoleReporter.RESET + ConsoleReporter.RED + "ERROR" + ConsoleReporter.RESET + " changeSet '2018010101'\n" +
+            "\t'test-rule': Some rather long message about the error\n" +
+            ConsoleReporter.RESET + ConsoleReporter.YELLOW + "IGNORED" + ConsoleReporter.RESET + " changeSet '2018010101'\n" +
             "\t'another-rule': Some other message about this rule\n\n", outContent.toString());
     }
 }

--- a/src/test/resources/integration/aggregate-errors.json
+++ b/src/test/resources/integration/aggregate-errors.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+      "no-preconditions": true,
+      "has-comment": true,
+      "has-context": true
+  }
+}

--- a/src/test/resources/integration/aggregate-errors.xml
+++ b/src/test/resources/integration/aggregate-errors.xml
@@ -1,0 +1,29 @@
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="201808281509" author="luke.rogers">
+        <sql>
+            SELECT 1 FROM DUAL
+        </sql>
+    </changeSet>
+
+    <changeSet id="2017010101" author="luke.rogers" context="test">
+        <comment>lql-ignore:has-comment</comment>
+        <update tableName="TEST">
+            <column name="TEST" value="TEST" />
+        </update>
+    </changeSet>
+
+    <changeSet id="2017010103" author="luke.rogers">
+        <preConditions>
+            <indexExists tableName="TEST" />
+        </preConditions>
+        <comment>lql-ignore:has-context</comment>
+        <update tableName="TEST">
+            <column name="TEST" value="TEST" />
+        </update>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/integration/aggregate-errors.xml
+++ b/src/test/resources/integration/aggregate-errors.xml
@@ -3,20 +3,20 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
 
-    <changeSet id="201808281509" author="luke.rogers">
+    <changeSet id="201808283523452" author="luke.rogers">
         <sql>
             SELECT 1 FROM DUAL
         </sql>
     </changeSet>
 
-    <changeSet id="2017010101" author="luke.rogers" context="test">
+    <changeSet id="2017013452354" author="luke.rogers" context="test">
         <comment>lql-ignore:has-comment</comment>
         <update tableName="TEST">
             <column name="TEST" value="TEST" />
         </update>
     </changeSet>
 
-    <changeSet id="2017010103" author="luke.rogers">
+    <changeSet id="20170245245" author="luke.rogers">
         <preConditions>
             <indexExists tableName="TEST" />
         </preConditions>

--- a/src/test/resources/integration/duplicate-includes.json
+++ b/src/test/resources/integration/duplicate-includes.json
@@ -1,4 +1,5 @@
 {
+  "fail-fast": true,
   "rules": {
     "no-duplicate-includes": true
   }

--- a/src/test/resources/integration/file-name-no-spaces.json
+++ b/src/test/resources/integration/file-name-no-spaces.json
@@ -1,4 +1,5 @@
 {
+  "fail-fast": true,
   "rules": {
     "file-name-no-spaces": {}
   }

--- a/src/test/resources/integration/foreign-key-name-complex.json
+++ b/src/test/resources/integration/foreign-key-name-complex.json
@@ -1,4 +1,5 @@
 {
+    "fail-fast": true,
     "rules": {
         "foreign-key-name": {
             "errorMessage": "Foreign key constraint '%s' must be named, ending in _FK, and follow pattern '{base_table_name}_{parent_table_name}_FK' where space permits",

--- a/src/test/resources/integration/illegal-change-types-simple.json
+++ b/src/test/resources/integration/illegal-change-types-simple.json
@@ -1,4 +1,5 @@
 {
+  "fail-fast": true,
   "rules": {
     "illegal-change-types": {
       "values": [

--- a/src/test/resources/integration/illegal-change-types.json
+++ b/src/test/resources/integration/illegal-change-types.json
@@ -1,4 +1,5 @@
 {
+  "fail-fast": true,
   "rules": {
     "illegal-change-types": {
       "enabled": true,

--- a/src/test/resources/integration/primary-key-name-complex.json
+++ b/src/test/resources/integration/primary-key-name-complex.json
@@ -1,4 +1,5 @@
 {
+    "fail-fast": true,
     "rules": {
         "primary-key-name": {
             "errorMessage": "Primary key constraint '%s' must be named, ending with '_PK', and start with table name (unless too long)",

--- a/src/test/resources/integration/primary-key-name-simple.json
+++ b/src/test/resources/integration/primary-key-name-simple.json
@@ -1,4 +1,5 @@
 {
+    "fail-fast": true,
     "rules": {
         "primary-key-name": true
     }

--- a/src/test/resources/integration/specific-rule-ignore.json
+++ b/src/test/resources/integration/specific-rule-ignore.json
@@ -1,4 +1,5 @@
 {
+  "fail-fast": true,
   "rules": {
     "table-name-length": {
       "enabled": true,

--- a/src/test/resources/lqllint.test.json
+++ b/src/test/resources/lqllint.test.json
@@ -1,5 +1,6 @@
 {
   "ignore-context-pattern": "^baseline.*$",
+  "fail-fast": true,
   "rules": {
     "no-duplicate-includes": {},
     "schema-name": {


### PR DESCRIPTION
Fixes #20 

Change adds `fail-fast` config option. So now, by default, errors are aggregated and processed at the end. Currently added support for console report, but should easily be extensible to cover other reports  in the future, e.g. junit.

Also tweaked `LinterIntegrationTest` to reset `ChangeLogPaserFactory` after each test execution. This should ensure that new instance of `CustomXMLChangeLogSAXParser` is used for each integration test. Before this was problematic with this change because we got same instance of parser which meant that `rootPhysicalChangeLogLocation` was set during first test only. We rely on this for working out when parsing has finished so we can report on the execution.

Note: Think we could do with tidying up `RunningContext` but believe that will be really in scope of #27 and should be much easier once thats done.