### PR TITLE
Add support for json and yaml change log formats

### DIFF
--- a/src/main/java/liquibase/parser/ext/LintAwareChangeLogParser.java
+++ b/src/main/java/liquibase/parser/ext/LintAwareChangeLogParser.java
@@ -27,9 +27,9 @@ import java.util.Set;
 @SuppressWarnings("WeakerAccess")
 public class LintAwareChangeLogParser implements ChangeLogParser {
     private static final Collection<Reporter> REPORTERS = ImmutableList.of(new ConsoleReporter());
-    private static final CustomXMLChangeLogSAXParser xmlParser = new CustomXMLChangeLogSAXParser();
-    private static final JsonChangeLogParser jsonParser = new JsonChangeLogParser();
-    private static final YamlChangeLogParser yamlParser = new YamlChangeLogParser();
+    private static final CustomXMLChangeLogSAXParser XML_PARSER = new CustomXMLChangeLogSAXParser();
+    private static final JsonChangeLogParser JSON_PARSER = new JsonChangeLogParser();
+    private static final YamlChangeLogParser YAML_PARSER = new YamlChangeLogParser();
 
     protected final ConfigLoader configLoader = new ConfigLoader();
     private final Set<String> alreadyParsed = Sets.newConcurrentHashSet();
@@ -61,18 +61,18 @@ public class LintAwareChangeLogParser implements ChangeLogParser {
     }
 
     private DatabaseChangeLog getDatabaseChangeLog(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
-        if (xmlParser.supports(physicalChangeLogLocation, resourceAccessor)) {
+        if (XML_PARSER.supports(physicalChangeLogLocation, resourceAccessor)) {
             return parseXmlDatabaseChangeLog(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
-        } else if (jsonParser.supports(physicalChangeLogLocation, resourceAccessor)) {
-            return jsonParser.parse(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
-        } else if (yamlParser.supports(physicalChangeLogLocation, resourceAccessor)) {
-            return yamlParser.parse(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+        } else if (JSON_PARSER.supports(physicalChangeLogLocation, resourceAccessor)) {
+            return JSON_PARSER.parse(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+        } else if (YAML_PARSER.supports(physicalChangeLogLocation, resourceAccessor)) {
+            return YAML_PARSER.parse(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
         }
         throw new IllegalArgumentException("Change log file type not supported");
     }
 
     private DatabaseChangeLog parseXmlDatabaseChangeLog(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
-        ParsedNode parsedNode = xmlParser.parseToNode(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+        ParsedNode parsedNode = XML_PARSER.parseToNode(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
         if (parsedNode == null) {
             return null;
         }
@@ -99,9 +99,9 @@ public class LintAwareChangeLogParser implements ChangeLogParser {
 
     @Override
     public boolean supports(String changeLogFile, ResourceAccessor resourceAccessor) {
-        return xmlParser.supports(changeLogFile, resourceAccessor)
-            || jsonParser.supports(changeLogFile, resourceAccessor)
-            || yamlParser.supports(changeLogFile, resourceAccessor);
+        return XML_PARSER.supports(changeLogFile, resourceAccessor)
+            || JSON_PARSER.supports(changeLogFile, resourceAccessor)
+            || YAML_PARSER.supports(changeLogFile, resourceAccessor);
     }
 
     @Override

--- a/src/main/java/liquibase/parser/ext/LintAwareChangeLogParser.java
+++ b/src/main/java/liquibase/parser/ext/LintAwareChangeLogParser.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 
 @SuppressWarnings("WeakerAccess")
-public class LintAwareChangeLogSAXParser implements ChangeLogParser {
+public class LintAwareChangeLogParser implements ChangeLogParser {
     private static final Collection<Reporter> REPORTERS = ImmutableList.of(new ConsoleReporter());
     private static final CustomXMLChangeLogSAXParser xmlParser = new CustomXMLChangeLogSAXParser();
     private static final JsonChangeLogParser jsonParser = new JsonChangeLogParser();

--- a/src/main/java/liquibase/parser/ext/LintAwareChangeLogSAXParser.java
+++ b/src/main/java/liquibase/parser/ext/LintAwareChangeLogSAXParser.java
@@ -15,7 +15,9 @@ import liquibase.changelog.DatabaseChangeLog;
 import liquibase.exception.ChangeLogParseException;
 import liquibase.parser.ChangeLogParser;
 import liquibase.parser.core.ParsedNode;
+import liquibase.parser.core.json.JsonChangeLogParser;
 import liquibase.parser.core.xml.XMLChangeLogSAXParser;
+import liquibase.parser.core.yaml.YamlChangeLogParser;
 import liquibase.resource.ResourceAccessor;
 
 import java.util.Collection;
@@ -23,8 +25,12 @@ import java.util.Optional;
 import java.util.Set;
 
 @SuppressWarnings("WeakerAccess")
-public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implements ChangeLogParser {
+public class LintAwareChangeLogSAXParser implements ChangeLogParser {
     private static final Collection<Reporter> REPORTERS = ImmutableList.of(new ConsoleReporter());
+    private static final CustomXMLChangeLogSAXParser xmlParser = new CustomXMLChangeLogSAXParser();
+    private static final JsonChangeLogParser jsonParser = new JsonChangeLogParser();
+    private static final YamlChangeLogParser yamlParser = new YamlChangeLogParser();
+
     protected final ConfigLoader configLoader = new ConfigLoader();
     private final Set<String> alreadyParsed = Sets.newConcurrentHashSet();
     private final ChangeLogLinter changeLogLinter = new ChangeLogLinter();
@@ -39,12 +45,37 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
 
         loadConfig(resourceAccessor);
 
-        ParsedNode parsedNode = parseToNode(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
-        if (parsedNode == null) {
-            return null;
+        DatabaseChangeLog changeLog = getDatabaseChangeLog(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+
+        if (!changeLog.getChangeSets().isEmpty()) {
+            checkDuplicateIncludes(physicalChangeLogLocation, config);
         }
 
         RuleRunner ruleRunner = config.getRuleRunner();
+
+        changeLogLinter.lintChangeLog(changeLog, config, ruleRunner);
+
+        runReports(physicalChangeLogLocation, ruleRunner.getReport());
+
+        return changeLog;
+    }
+
+    private DatabaseChangeLog getDatabaseChangeLog(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
+        if (xmlParser.supports(physicalChangeLogLocation, resourceAccessor)) {
+            return parseXmlDatabaseChangeLog(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+        } else if (jsonParser.supports(physicalChangeLogLocation, resourceAccessor)) {
+            return jsonParser.parse(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+        } else if (yamlParser.supports(physicalChangeLogLocation, resourceAccessor)) {
+            return yamlParser.parse(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+        }
+        throw new IllegalArgumentException("Change log file type not supported");
+    }
+
+    private DatabaseChangeLog parseXmlDatabaseChangeLog(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
+        ParsedNode parsedNode = xmlParser.parseToNode(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+        if (parsedNode == null) {
+            return null;
+        }
 
         DatabaseChangeLog changeLog = new DatabaseChangeLog(physicalChangeLogLocation);
         changeLog.setChangeLogParameters(changeLogParameters);
@@ -53,15 +84,6 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
         } catch (Exception e) {
             throw new ChangeLogParseException(e);
         }
-
-        if (!changeLog.getChangeSets().isEmpty()) {
-            checkDuplicateIncludes(physicalChangeLogLocation, config);
-        }
-
-        changeLogLinter.lintChangeLog(changeLog, config, ruleRunner);
-
-        runReports(physicalChangeLogLocation, ruleRunner.getReport());
-
         return changeLog;
     }
 
@@ -77,7 +99,9 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
 
     @Override
     public boolean supports(String changeLogFile, ResourceAccessor resourceAccessor) {
-        return changeLogFile.toLowerCase().endsWith("xml");
+        return xmlParser.supports(changeLogFile, resourceAccessor)
+            || jsonParser.supports(changeLogFile, resourceAccessor)
+            || yamlParser.supports(changeLogFile, resourceAccessor);
     }
 
     @Override
@@ -100,6 +124,15 @@ public class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implement
             }
             alreadyParsed.add(physicalChangeLogLocation);
         }
+    }
+
+    public static class CustomXMLChangeLogSAXParser extends XMLChangeLogSAXParser implements ChangeLogParser {
+
+        @Override
+        public ParsedNode parseToNode(String physicalChangeLogLocation, ChangeLogParameters changeLogParameters, ResourceAccessor resourceAccessor) throws ChangeLogParseException {
+            return super.parseToNode(physicalChangeLogLocation, changeLogParameters, resourceAccessor);
+        }
+
     }
 
 }

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/HasCommentIntegrationTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/HasCommentIntegrationTest.java
@@ -12,17 +12,39 @@ class HasCommentIntegrationTest extends LinterIntegrationTest {
     @Override
     List<IntegrationTestConfig> getTests() {
         IntegrationTestConfig test1 = IntegrationTestConfig.shouldFail(
-            "Should fail with no comment",
+            "Should fail with no comment xml",
             "has-comment/has-comment-fail.xml",
             "has-comment/lqllint.json",
             "Change set must have a comment");
 
         IntegrationTestConfig test2 = IntegrationTestConfig.shouldPass(
-            "Should pass with a comment",
+            "Should pass with a comment xml",
             "has-comment/has-comment-pass.xml",
             "has-comment/lqllint.json");
 
-        return Arrays.asList(test1, test2);
+        IntegrationTestConfig test3 = IntegrationTestConfig.shouldFail(
+            "Should fail with no comment json",
+            "has-comment/has-comment-fail.json",
+            "has-comment/lqllint.json",
+            "Change set must have a comment");
+
+        IntegrationTestConfig test4 = IntegrationTestConfig.shouldPass(
+            "Should pass with a comment json",
+            "has-comment/has-comment-pass.xml",
+            "has-comment/lqllint.json");
+
+        IntegrationTestConfig test5 = IntegrationTestConfig.shouldFail(
+            "Should fail with no comment yaml",
+            "has-comment/has-comment-fail.yaml",
+            "has-comment/lqllint.json",
+            "Change set must have a comment");
+
+        IntegrationTestConfig test6 = IntegrationTestConfig.shouldPass(
+            "Should pass with a comment yaml",
+            "has-comment/has-comment-pass.yaml",
+            "has-comment/lqllint.json");
+
+        return Arrays.asList(test1, test2, test3, test4, test5, test6);
     }
 
 }

--- a/src/test/java/liquibase/parser/ext/ConfigAwareCustomXMLChangeLogSAXParser.java
+++ b/src/test/java/liquibase/parser/ext/ConfigAwareCustomXMLChangeLogSAXParser.java
@@ -2,7 +2,7 @@ package liquibase.parser.ext;
 
 import liquibase.resource.ResourceAccessor;
 
-public class ConfigAwareCustomXMLChangeLogSAXParser extends CustomXMLChangeLogSAXParser {
+public class ConfigAwareCustomXMLChangeLogSAXParser extends LintAwareChangeLogSAXParser {
 
     @Override
     protected void loadConfig(ResourceAccessor resourceAccessor) {

--- a/src/test/java/liquibase/parser/ext/ConfigAwareCustomXMLChangeLogSAXParser.java
+++ b/src/test/java/liquibase/parser/ext/ConfigAwareCustomXMLChangeLogSAXParser.java
@@ -2,7 +2,7 @@ package liquibase.parser.ext;
 
 import liquibase.resource.ResourceAccessor;
 
-public class ConfigAwareCustomXMLChangeLogSAXParser extends LintAwareChangeLogSAXParser {
+public class ConfigAwareCustomXMLChangeLogSAXParser extends LintAwareChangeLogParser {
 
     @Override
     protected void loadConfig(ResourceAccessor resourceAccessor) {

--- a/src/test/java/liquibase/parser/ext/CustomXMLChangeLogSAXParserTest.java
+++ b/src/test/java/liquibase/parser/ext/CustomXMLChangeLogSAXParserTest.java
@@ -15,7 +15,7 @@ class CustomXMLChangeLogSAXParserTest {
 
     @Test
     void shouldPreventDuplicateIncludes(Config config) throws Exception {
-        LintAwareChangeLogSAXParser parser = new LintAwareChangeLogSAXParser();
+        LintAwareChangeLogParser parser = new LintAwareChangeLogParser();
 
         // do a couple includes
         parser.checkDuplicateIncludes("foo/bar/baz.xml", config);

--- a/src/test/java/liquibase/parser/ext/CustomXMLChangeLogSAXParserTest.java
+++ b/src/test/java/liquibase/parser/ext/CustomXMLChangeLogSAXParserTest.java
@@ -15,7 +15,7 @@ class CustomXMLChangeLogSAXParserTest {
 
     @Test
     void shouldPreventDuplicateIncludes(Config config) throws Exception {
-        CustomXMLChangeLogSAXParser parser = new CustomXMLChangeLogSAXParser();
+        LintAwareChangeLogSAXParser parser = new LintAwareChangeLogSAXParser();
 
         // do a couple includes
         parser.checkDuplicateIncludes("foo/bar/baz.xml", config);

--- a/src/test/resources/integration/has-comment/has-comment-fail.json
+++ b/src/test/resources/integration/has-comment/has-comment-fail.json
@@ -1,0 +1,25 @@
+{
+    "databaseChangeLog": [
+        {
+            "changeSet": {
+                "id": "201809011238",
+                "author": "tester",
+                "changes": [
+                    {
+                        "insert": {
+                            "tableName": "FOO",
+                            "columns": [
+                                {
+                                    "column": {
+                                        "name": "BAR",
+                                        "value": "test value"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/test/resources/integration/has-comment/has-comment-fail.yaml
+++ b/src/test/resources/integration/has-comment/has-comment-fail.yaml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+
+    - changeSet:
+          id: 201809011238
+          author: tester
+          changes:
+              - insert:
+                    tableName: FOO
+                    columns:
+                        - column:
+                              name: BAR
+                              type: test value

--- a/src/test/resources/integration/has-comment/has-comment-pass.json
+++ b/src/test/resources/integration/has-comment/has-comment-pass.json
@@ -1,0 +1,26 @@
+{
+    "databaseChangeLog": [
+        {
+            "changeSet": {
+                "id": "201809011238",
+                "author": "tester",
+                "comment": "Some random comment",
+                "changes": [
+                    {
+                        "insert": {
+                            "tableName": "FOO",
+                            "columns": [
+                                {
+                                    "column": {
+                                        "name": "BAR",
+                                        "value": "test value"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/src/test/resources/integration/has-comment/has-comment-pass.yaml
+++ b/src/test/resources/integration/has-comment/has-comment-pass.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+
+    - changeSet:
+          id: 201809011238
+          author: tester
+          comment: some comment
+          changes:
+              - insert:
+                    tableName: FOO
+                    columns:
+                        - column:
+                              name: BAR
+                              type: test value


### PR DESCRIPTION
Adding support for [YAML](http://www.liquibase.org/documentation/yaml_format.html) and [JSON](http://www.liquibase.org/documentation/json_format.html) change log formats

Fixes #6 
Fixes #7 