### PR TITLE
support for multiple rule configs

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -37,6 +37,29 @@ All rules also support two standard options (other than `enabled`):
 
 Individual rules also support their own options; you can find these documented with those rules.
 
+## Multiple Configs
+
+Though you might not need it often, you can specify multiple configs - with different options - for the same rule. You can do this by providing an array of rule config objects rather than just one, as in this example:
+
+```json
+{
+    "rules": {
+        "object-name": [
+            {
+                "pattern": "^(?!_)[A-Z_0-9]+(?<!_)$",
+                "errorMessage": "Object name '%s' name must be uppercase and use '_' separation"
+            },
+            {
+                "pattern": "^POWER.*$",
+                "errorMessage": "Object name '%s' name must begin with 'POWER'"
+            }
+        ]
+    }
+}
+```
+
+If you provide multiple configs, each applicable change/changeset/changelog will be checked with all of the configs in turn. A failure on any of the configs will be treated as a failure - in other words, your scripts have to pass against all the configs, so the logic is "AND" rather than "OR".
+
 ## Failure
 
 Once a rule is switched on, it will be run against each of your scripts right after Liquibase parses them from their source format (e.g. XML). If a rule fails (that is, a script broke the rule) then Liquibase will exit with a `ChangeLogParseException` containing details of which change failed and why, and nothing will be run into the target database.

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/Config.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/Config.java
@@ -50,6 +50,10 @@ public class Config {
         return rules;
     }
 
+    public List<RuleConfig> forRule(String ruleName) {
+        return rules.get(ruleName);
+    }
+
     public RuleRunner getRuleRunner() {
         return new RuleRunner(this);
     }

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/AbstractLintRule.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/AbstractLintRule.java
@@ -26,6 +26,8 @@ public abstract class AbstractLintRule implements LintRule {
         this.ruleConfig = ruleConfig;
         if (ruleConfig.hasPattern()) {
             this.patternChecker = new PatternChecker(ruleConfig);
+        } else {
+            this.patternChecker = null;
         }
     }
 

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
@@ -49,7 +49,7 @@ public class RuleRunner {
 
     private boolean filterAndConfigureRule(LintRule rule) {
         if (rule != null && config.isRuleEnabled(rule.getName())) {
-            rule.configure(config.getRules().get(rule.getName()));
+            rule.configure(config.getRules().get(rule.getName()).get(0));
             return true;
         }
         return false;

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunner.java
@@ -150,12 +150,14 @@ public class RuleRunner {
         }
 
         private boolean shouldApply(RuleConfig ruleConfig, String ruleKey, String errorMessage) {
-            final boolean ignored = isIgnored(ruleKey);
-            if (ignored) {
+            if (!evaluateCondition(ruleConfig, change)) {
+                return false;
+            }
+            if (isIgnored(ruleKey)) {
                 reportItems.add(ReportItem.ignored(databaseChangeLog, changeSet, ruleKey, errorMessage));
                 return false;
             }
-            return evaluateCondition(ruleConfig, change) && !ignored;
+            return true;
         }
 
         private boolean evaluateCondition(RuleConfig ruleConfig, Change change) {

--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Report.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/report/Report.java
@@ -22,6 +22,10 @@ public class Report {
         return reportItems.stream().filter(item -> item.getType() == ReportItem.ReportItemType.ERROR).count();
     }
 
+    public long countIgnored() {
+        return reportItems.stream().filter(item -> item.getType() == ReportItem.ReportItemType.IGNORED).count();
+    }
+
     public boolean hasItems() {
         return !reportItems.isEmpty();
     }

--- a/src/main/java/liquibase/parser/ext/LintAwareChangeLogParser.java
+++ b/src/main/java/liquibase/parser/ext/LintAwareChangeLogParser.java
@@ -116,8 +116,10 @@ public class LintAwareChangeLogParser implements ChangeLogParser {
     }
 
     void checkDuplicateIncludes(String physicalChangeLogLocation, Config config) throws ChangeLogParseException {
-        RuleConfig ruleConfig = config.getRules().get("no-duplicate-includes");
-        if (ruleConfig != null && ruleConfig.isEnabled()) {
+        RuleConfig ruleConfig = config.getRules().get("no-duplicate-includes").stream()
+            .filter(RuleConfig::isEnabled)
+            .findAny().orElse(null);
+        if (ruleConfig != null) {
             if (alreadyParsed.contains(physicalChangeLogLocation)) {
                 final String errorMessage = Optional.ofNullable(ruleConfig.getErrorMessage()).orElse("Changelog file '%s' was included more than once");
                 throw new ChangeLogParseException(String.format(errorMessage, physicalChangeLogLocation));

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinterTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/ChangeLogLinterTest.java
@@ -1,6 +1,6 @@
 package com.whiteclarkegroup.liquibaselinter;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.whiteclarkegroup.liquibaselinter.config.Config;
 import com.whiteclarkegroup.liquibaselinter.config.rules.RuleRunner;
@@ -42,7 +42,7 @@ class ChangeLogLinterTest {
     @DisplayName("Should lint change sets with standard comment")
     @Test
     void shouldLintChangeSetsWithStandardComment() throws ChangeLogParseException {
-        Config config = new Config(null, ImmutableMap.of(), true);
+        Config config = new Config(null, ImmutableListMultimap.of(), true);
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("ddl_test"), "Test Data column");
         changeLogLinter.lintChangeLog(databaseChangeLog, config, new RuleRunner(config));
@@ -62,7 +62,7 @@ class ChangeLogLinterTest {
     @DisplayName("Should not fall over on null comment")
     @Test
     void shouldNotFallOverOnNullComment() throws ChangeLogParseException {
-        Config config = new Config(null, ImmutableMap.of(), true);
+        Config config = new Config(null, ImmutableListMultimap.of(), true);
         DatabaseChangeLog databaseChangeLog = mock(DatabaseChangeLog.class);
         ChangeSet changeSet = getChangeSet(databaseChangeLog, ImmutableSet.of("ddl_test"), "Comment");
         changeLogLinter.lintChangeLog(databaseChangeLog, config, new RuleRunner(config));

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
@@ -61,6 +61,27 @@ class ConfigTest {
         assertTrue(ruleConfig.isEnabled());
     }
 
+    @DisplayName("Should support having an array of configs for one rule")
+    @Test
+    void shouldSupportArrayOfRuleConfigs() throws IOException {
+        String configJson = "{\n" +
+            "    \"rules\": {\n" +
+            "        \"object-name\": [\n" +
+            "            {\n" +
+            "                \"pattern\": \"^(?!_)[A-Z_0-9]+(?<!_)$\",\n" +
+            "                \"errorMessage\": \"Object name '%s' name must be uppercase and use '_' separation\"\n" +
+            "            },\n" +
+            "            {\n" +
+            "                \"pattern\": \"^POWER.*$\",\n" +
+            "                \"errorMessage\": \"Object name '%s' name must begin with 'POWER'\"\n" +
+            "            }\n" +
+            "        ]\n" +
+            "    }\n" +
+            "}\n";
+        Config config = OBJECT_MAPPER.readValue(configJson, Config.class);
+        assertEquals(2, config.getRules().size());
+    }
+
     @DisplayName("Should return disabled rule for null config object")
     @Test
     void shouldReturnDisabledRuleForNullConfigObject() throws IOException {

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
@@ -39,12 +39,12 @@ class ConfigTest {
     void shouldNotSupportInValidConfigObject() throws IOException {
         String configJson = "{\n" +
             "  \"rules\": {\n" +
-            "    \"no-duplicate-includes\": []\n" +
+            "    \"no-duplicate-includes\": \"foo\"\n" +
             "  }\n" +
             "}";
         JsonMappingException mappingException =
             assertThrows(JsonMappingException.class, () -> OBJECT_MAPPER.readValue(configJson, Config.class));
-        assertTrue(mappingException.getMessage().contains("Cannot deserialize instance of `com.whiteclarkegroup.liquibaselinter.config.rules.RuleConfig$RuleConfigBuilder`"));
+        assertTrue(mappingException.getMessage().contains("instance of `com.whiteclarkegroup.liquibaselinter.config.rules.RuleConfig$RuleConfigBuilder`"));
     }
 
     @DisplayName("Should support having rule config value as boolean")
@@ -52,7 +52,7 @@ class ConfigTest {
     void shouldSupportHavingRuleConfigAsBoolean() throws IOException {
         String configJson = "{\n" +
             "  \"rules\": {\n" +
-            "    \"file-name-no-spaces\": {}\n" +
+            "    \"file-name-no-spaces\": true\n" +
             "  }\n" +
             "}";
         Config config = OBJECT_MAPPER.readValue(configJson, Config.class);

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/ConfigTest.java
@@ -2,13 +2,13 @@ package com.whiteclarkegroup.liquibaselinter.config.rules;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.whiteclarkegroup.liquibaselinter.config.Config;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -30,7 +30,7 @@ class ConfigTest {
             "}";
         Config config = OBJECT_MAPPER.readValue(configJson, Config.class);
         assertEquals(1, config.getRules().size());
-        RuleConfig ruleConfig = config.getRules().get("schema-name");
+        RuleConfig ruleConfig = config.getRules().get("schema-name").get(0);
         assertTrue(ruleConfig.isEnabled());
     }
 
@@ -57,7 +57,7 @@ class ConfigTest {
             "}";
         Config config = OBJECT_MAPPER.readValue(configJson, Config.class);
         assertEquals(1, config.getRules().size());
-        RuleConfig ruleConfig = config.getRules().get("file-name-no-spaces");
+        RuleConfig ruleConfig = config.getRules().get("file-name-no-spaces").get(0);
         assertTrue(ruleConfig.isEnabled());
     }
 
@@ -71,14 +71,14 @@ class ConfigTest {
             "}";
         Config config = OBJECT_MAPPER.readValue(configJson, Config.class);
         assertEquals(1, config.getRules().size());
-        RuleConfig ruleConfig = config.getRules().get("file-name-no-spaces");
+        RuleConfig ruleConfig = config.getRules().get("file-name-no-spaces").get(0);
         assertFalse(ruleConfig.isEnabled());
     }
 
     @DisplayName("Should indicate whether rule enabled from config map")
     @Test
     void shouldIndicateWhetherRuleEnabledFromConfigMap() {
-        Map<String, RuleConfig> map = ImmutableMap.of(
+        ListMultimap<String, RuleConfig> map = ImmutableListMultimap.of(
             "present-but-off", RuleConfig.disabled(),
             "present-and-on", RuleConfig.enabled()
         );

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
@@ -9,31 +9,111 @@ import liquibase.exception.ChangeLogParseException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings("unchecked")
 class RuleRunnerTest {
-
-    @DisplayName("Should support ignoring specific rule types")
+    @DisplayName("Should add rule violation to report as an error")
     @Test
-    void shouldSupportSpecificRuleTypeIgnore() throws ChangeLogParseException {
-        RuleRunner ruleRunner = getRuleRunner();
-        ruleRunner.forChange(mockChange("Test comment lql-ignore:table-name")).checkChange();
+    void shouldReportErrorsForFailureWhenNotIgnored() throws ChangeLogParseException {
+        RuleRunner ruleRunner = ruleRunnerWithTableNameRule(null, false);
+
+        ruleRunner.forChange(mockInvalidChange(null)).checkChange();
+
+        assertEquals(0, ruleRunner.getReport().countIgnored());
+        assertEquals(1, ruleRunner.getReport().countErrors());
+        assertEquals("Table name does not follow pattern", ruleRunner.getReport().getReportItems().iterator().next().getMessage());
+    }
+
+    @DisplayName("Should add rule violation to report as ignored, when an ignore comment matches")
+    @Test
+    void shouldReportIgnoredWhenIgnored() throws ChangeLogParseException {
+        RuleRunner ruleRunner = ruleRunnerWithTableNameRule(null, false);
+
+        ruleRunner.forChange(mockInvalidChange("Test comment lql-ignore:table-name")).checkChange();
+
+        assertEquals(0, ruleRunner.getReport().countErrors());
+        assertEquals(1, ruleRunner.getReport().countIgnored());
+        assertEquals("Table name does not follow pattern", ruleRunner.getReport().getReportItems().iterator().next().getMessage());
+    }
+
+    @DisplayName("Should throw exception for rule violation when fail-fast is on")
+    @Test
+    void shouldThrowForErrorsWhenFailFastOn() {
+        RuleRunner ruleRunner = ruleRunnerWithTableNameRule(null, true);
 
         ChangeLogParseException changeLogParseException =
-            assertThrows(ChangeLogParseException.class, () -> ruleRunner.forChange(mockChange(null)).checkChange());
+            assertThrows(ChangeLogParseException.class, () -> ruleRunner.forChange(mockInvalidChange(null)).checkChange());
 
         assertTrue(changeLogParseException.getMessage().contains("Table name does not follow pattern"));
     }
 
-    private RuleRunner getRuleRunner() {
-        final ListMultimap<String, RuleConfig> ruleConfigMap = ImmutableListMultimap.of("table-name", RuleConfig.builder().withEnabled(true).withPattern("^(?!TBL)[A-Z_]+(?<!_)$").build());
-        return new RuleRunner(new Config(null, ruleConfigMap, true));
+    @DisplayName("Should do nothing for rule violation when ignored via comment and fail-fast is on")
+    @Test
+    void shouldNotThrowForIgnoredWhenFailFastOn() throws ChangeLogParseException {
+        RuleRunner ruleRunner = ruleRunnerWithTableNameRule(null, true);
+
+        ruleRunner.forChange(mockInvalidChange("Test comment lql-ignore:table-name")).checkChange();
+
+        // expect nothing thrown
     }
 
-    private Change mockChange(String changeComment) {
+    @DisplayName("Should add rule violation to report as an error when condition resolves to true")
+    @Test
+    void shouldReportErrorWhenConditionTrue() throws ChangeLogParseException {
+        RuleRunner ruleRunner = ruleRunnerWithTableNameRule("true", false);
+
+        ruleRunner.forChange(mockInvalidChange(null)).checkChange();
+
+        assertEquals(0, ruleRunner.getReport().countIgnored());
+        assertEquals(1, ruleRunner.getReport().countErrors());
+        assertEquals("Table name does not follow pattern", ruleRunner.getReport().getReportItems().iterator().next().getMessage());
+    }
+
+    @DisplayName("Should add rule violation to report as ignored when condition resolves to false")
+    @Test
+    void shouldReportIgnoredWhenConditionTrue() throws ChangeLogParseException {
+        RuleRunner ruleRunner = ruleRunnerWithTableNameRule("true", false);
+
+        ruleRunner.forChange(mockInvalidChange("Test comment lql-ignore:table-name")).checkChange();
+
+        assertEquals(0, ruleRunner.getReport().countErrors());
+        assertEquals(1, ruleRunner.getReport().countIgnored());
+        assertEquals("Table name does not follow pattern", ruleRunner.getReport().getReportItems().iterator().next().getMessage());
+    }
+
+    @DisplayName("Should not report violation when condition resolves to false")
+    @Test
+    void shouldNotReportErrorWhenConditionFalse() throws ChangeLogParseException {
+        RuleRunner ruleRunner = ruleRunnerWithTableNameRule("false", false);
+
+        ruleRunner.forChange(mockInvalidChange(null)).checkChange();
+
+        assertFalse(ruleRunner.getReport().hasItems());
+    }
+
+    @DisplayName("Should not report ignored violation when condition resolves to false")
+    @Test
+    void shouldNotReportIgnoredWhenConditionFalse() throws ChangeLogParseException {
+        RuleRunner ruleRunner = ruleRunnerWithTableNameRule("false", false);
+
+        ruleRunner.forChange(mockInvalidChange("Test comment lql-ignore:table-name")).checkChange();
+
+        assertFalse(ruleRunner.getReport().hasItems());
+    }
+
+    private RuleRunner ruleRunnerWithTableNameRule(String condition, boolean failFast) {
+        final ListMultimap<String, RuleConfig> ruleConfigMap = ImmutableListMultimap.of(
+            "table-name", RuleConfig.builder()
+                .withEnabled(true)
+                .withPattern("^(?!TBL)[A-Z_]+(?<!_)$")
+                .withCondition(condition)
+                .build());
+        return new RuleRunner(new Config(null, ruleConfigMap, failFast));
+    }
+
+    private Change mockInvalidChange(String changeComment) {
         RenameTableChange change = mock(RenameTableChange.class, RETURNS_DEEP_STUBS);
         when(change.getNewTableName()).thenReturn("TBL_TABLE");
         when(change.getChangeSet().getComments()).thenReturn(changeComment);

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
@@ -1,6 +1,7 @@
 package com.whiteclarkegroup.liquibaselinter.config.rules;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
 import com.whiteclarkegroup.liquibaselinter.config.Config;
 import liquibase.change.Change;
 import liquibase.change.core.RenameTableChange;
@@ -28,7 +29,7 @@ class RuleRunnerTest {
     }
 
     private RuleRunner getRuleRunner() {
-        final ImmutableMap<String, RuleConfig> ruleConfigMap = ImmutableMap.of("table-name", RuleConfig.builder().withEnabled(true).withPattern("^(?!TBL)[A-Z_]+(?<!_)$").build());
+        final ListMultimap<String, RuleConfig> ruleConfigMap = ImmutableListMultimap.of("table-name", RuleConfig.builder().withEnabled(true).withPattern("^(?!TBL)[A-Z_]+(?<!_)$").build());
         return new RuleRunner(new Config(null, ruleConfigMap, true));
     }
 

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/RuleRunnerTest.java
@@ -49,14 +49,16 @@ class RuleRunnerTest {
         assertTrue(changeLogParseException.getMessage().contains("Table name does not follow pattern"));
     }
 
-    @DisplayName("Should do nothing for rule violation when ignored via comment and fail-fast is on")
+    @DisplayName("Should report rule violation as ignored when ignored via comment and fail-fast is on")
     @Test
     void shouldNotThrowForIgnoredWhenFailFastOn() throws ChangeLogParseException {
         RuleRunner ruleRunner = ruleRunnerWithTableNameRule(null, true);
 
         ruleRunner.forChange(mockInvalidChange("Test comment lql-ignore:table-name")).checkChange();
 
-        // expect nothing thrown
+        assertEquals(0, ruleRunner.getReport().countErrors());
+        assertEquals(1, ruleRunner.getReport().countIgnored());
+        assertEquals("Table name does not follow pattern", ruleRunner.getReport().getReportItems().iterator().next().getMessage());
     }
 
     @DisplayName("Should add rule violation to report as an error when condition resolves to true")

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/MultipleRuleConfigsIntegrationTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/MultipleRuleConfigsIntegrationTest.java
@@ -1,0 +1,34 @@
+package com.whiteclarkegroup.liquibaselinter.integration;
+
+import com.whiteclarkegroup.liquibaselinter.resolvers.LiquibaseIntegrationTestResolver;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+@ExtendWith(LiquibaseIntegrationTestResolver.class)
+class MultipleRuleConfigsIntegrationTest extends LinterIntegrationTest {
+
+    @Override
+    List<IntegrationTestConfig> getTests() {
+        IntegrationTestConfig test1 = IntegrationTestConfig.shouldFail(
+            "Should fail on the uppercase etc pattern",
+            "multiple-rule-configs/fail-first.xml",
+            "multiple-rule-configs/lqllint.json",
+            "Object name 'nope' name must be uppercase and use '_' separation");
+
+        IntegrationTestConfig test2 = IntegrationTestConfig.shouldFail(
+            "Should fail on the prefix pattern",
+            "multiple-rule-configs/fail-second.xml",
+            "multiple-rule-configs/lqllint.json",
+            "Object name 'NOPE' name must begin with 'POWER'");
+
+        IntegrationTestConfig test3 = IntegrationTestConfig.shouldPass(
+            "Should pass with mutiple configs if they all pass",
+            "multiple-rule-configs/pass.xml",
+            "multiple-rule-configs/lqllint.json");
+
+        return Arrays.asList(test1, test2, test3);
+    }
+
+}

--- a/src/test/resources/integration/multiple-rule-configs/fail-first.xml
+++ b/src/test/resources/integration/multiple-rule-configs/fail-first.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet author="lrogers" context="" id="201811070940">
+        <comment>Table</comment>
+        <addColumn tableName="TEST">
+            <column name="nope" type="NVARCHAR(00)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/integration/multiple-rule-configs/fail-second.xml
+++ b/src/test/resources/integration/multiple-rule-configs/fail-second.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet author="lrogers" context="" id="201811070940">
+        <comment>Table</comment>
+        <addColumn tableName="TEST">
+            <column name="NOPE" type="NVARCHAR(00)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/integration/multiple-rule-configs/lqllint.json
+++ b/src/test/resources/integration/multiple-rule-configs/lqllint.json
@@ -1,0 +1,15 @@
+{
+    "fail-fast": true,
+    "rules": {
+        "object-name": [
+            {
+                "pattern": "^(?!_)[A-Z_0-9]+(?<!_)$",
+                "errorMessage": "Object name '%s' name must be uppercase and use '_' separation"
+            },
+            {
+                "pattern": "^POWER.*$",
+                "errorMessage": "Object name '%s' name must begin with 'POWER'"
+            }
+        ]
+    }
+}

--- a/src/test/resources/integration/multiple-rule-configs/pass.xml
+++ b/src/test/resources/integration/multiple-rule-configs/pass.xml
@@ -1,0 +1,13 @@
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet author="lrogers" context="" id="201811070940">
+        <comment>Table</comment>
+        <addColumn tableName="TEST">
+            <column name="POWER_THINGY" type="NVARCHAR(00)"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
This adds support for multiple configs for the same rule, expressed as an array of objects as the value in the map in the config file. The aim was to make this a non-breaking change, so all existing configs, rule implementations, unit and integration tests would continue to work unchanged.

TODO:

- [x] Add documentation