### PR TITLE
Fix build, snake yaml optional again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: java
 jdk:
 - openjdk8
 script:
-    - mvn test -B
+    - mvn test -B -Dyaml.version=1.24
     - ./build-scripts/run-tests-liquibase-versions.sh

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <junit.jupiter.version>5.5.1</junit.jupiter.version>
         <guava.version>28.0-jre</guava.version>
         <mockito.version>3.0.0</mockito.version>
-        <jackson.version>2.9.9.2</jackson.version>
+        <jackson.version>2.10.0</jackson.version>
         <commons-beanutils.version>1.9.3</commons-beanutils.version>
         <spring.version>5.1.8.RELEASE</spring.version>
         <jansi.version>1.17.1</jansi.version>


### PR DESCRIPTION
Seems that snake yaml is optional once again hence the build is failing as it expects it to be on the classpath. We already have profile support for including yaml as it was previously optional before 3.5.x. Certainly room for improvement here I think but needs a bit of thought. This will get the build fixed for now.