### PR TITLE
Dependency version updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,14 +54,14 @@
     <properties>
         <!-- libraries -->
         <liquibase.version>[3.4.0,3.9.0)</liquibase.version>
-        <junit.jupiter.version>5.5.1</junit.jupiter.version>
-        <guava.version>28.0-jre</guava.version>
-        <mockito.version>3.0.0</mockito.version>
-        <jackson.version>2.10.0</jackson.version>
-        <commons-beanutils.version>1.9.3</commons-beanutils.version>
-        <spring.version>5.1.8.RELEASE</spring.version>
+        <junit.jupiter.version>5.5.2</junit.jupiter.version>
+        <guava.version>28.1-jre</guava.version>
+        <mockito.version>3.1.0</mockito.version>
+        <jackson.version>2.10.1</jackson.version>
+        <commons-beanutils.version>1.9.4</commons-beanutils.version>
+        <spring.version>5.2.1.RELEASE</spring.version>
         <jansi.version>1.17.1</jansi.version>
-        <auto-service.version>1.0-rc5</auto-service.version>
+        <auto-service.version>1.0-rc6</auto-service.version>
         <yaml.version>1.24</yaml.version>
         <!-- plugins -->
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
@@ -127,6 +127,7 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>${yaml.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Including making `snakeyaml` provided as the version is different depending on which version of liquibase you are using the linter against.