### PR TITLE
skip enforcing hasComment rule if change is a tagDatabase

### DIFF
--- a/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/core/HasCommentRuleImpl.java
+++ b/src/main/java/com/whiteclarkegroup/liquibaselinter/config/rules/core/HasCommentRuleImpl.java
@@ -3,6 +3,7 @@ package com.whiteclarkegroup.liquibaselinter.config.rules.core;
 import com.google.auto.service.AutoService;
 import com.whiteclarkegroup.liquibaselinter.config.rules.AbstractLintRule;
 import com.whiteclarkegroup.liquibaselinter.config.rules.ChangeSetRule;
+import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeSet;
 
 @AutoService({ChangeSetRule.class})
@@ -16,6 +17,14 @@ public class HasCommentRuleImpl extends AbstractLintRule implements ChangeSetRul
 
     @Override
     public boolean invalid(ChangeSet changeSet) {
+        if (changeSet.getChanges().stream().anyMatch(change -> change instanceof TagDatabaseChange)) {
+            /*
+            https://github.com/whiteclarkegroup/liquibase-linter/issues/90
+            tagDatabase changes cannot have any siblings in a changeSet - not even comments
+            so we have to make an exception here
+             */
+            return false;
+        }
         return checkNotBlank(changeSet.getComments());
     }
 }

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/core/HasCommentsRuleImplTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/config/rules/core/HasCommentsRuleImplTest.java
@@ -1,8 +1,11 @@
 package com.whiteclarkegroup.liquibaselinter.config.rules.core;
 
+import liquibase.change.core.TagDatabaseChange;
 import liquibase.changelog.ChangeSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,6 +18,15 @@ class HasCommentsRuleImplTest {
     void shouldPassWithPopulatedComment() {
         ChangeSet changeSet = mock(ChangeSet.class, RETURNS_DEEP_STUBS);
         when(changeSet.getComments()).thenReturn("Some comment");
+        assertFalse(new HasCommentRuleImpl().invalid(changeSet));
+    }
+
+    @DisplayName("Should pass when changeSet contains only a tagDatabase change")
+    @Test
+    void shouldPassWithTagDatabase() {
+        ChangeSet changeSet = mock(ChangeSet.class, RETURNS_DEEP_STUBS);
+        when(changeSet.getComments()).thenReturn(null);
+        when(changeSet.getChanges()).thenReturn(Collections.singletonList(mock(TagDatabaseChange.class)));
         assertFalse(new HasCommentRuleImpl().invalid(changeSet));
     }
 

--- a/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/HasCommentIntegrationTest.java
+++ b/src/test/java/com/whiteclarkegroup/liquibaselinter/integration/HasCommentIntegrationTest.java
@@ -19,6 +19,11 @@ class HasCommentIntegrationTest extends LinterIntegrationTest {
             "has-comment/has-comment-pass.xml",
             "has-comment/lqllint.json");
 
+        shouldPass(
+            "Should pass with a tagDatabase change and no comment",
+            "has-comment/has-comment-tagdatabase-pass.xml",
+            "has-comment/lqllint.json");
+
         shouldFail(
             "Should fail with no comment json",
             "has-comment/has-comment-fail.json",

--- a/src/test/resources/integration/has-comment/has-comment-tagdatabase-pass.xml
+++ b/src/test/resources/integration/has-comment/has-comment-tagdatabase-pass.xml
@@ -1,0 +1,10 @@
+<databaseChangeLog
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.3.xsd">
+
+    <changeSet id="201809011238" author="luke.rogers">
+        <tagDatabase tag="foo"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Fixes #90.

We probably want to raise an issue against Liquibase for this, there seems no reason not to allow a comment, this may just have been an oversight where the intent was to prevent any other changes